### PR TITLE
[C++]: add origin prefix for GIT_TAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ endif(NOT AERON_GIT_URL)
 ExternalProject_Add(
     aeron
     GIT_REPOSITORY ${AERON_GIT_URL}
-    GIT_TAG "head"
+    GIT_TAG "origin/HEAD"
     CMAKE_ARGS "-DAERON_TESTS=OFF" "-DCMAKE_BUILD_TYPE=Release"
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION
error during C++ benchmarks compilition

fatal: invalid reference: head
CMake Error at /Projects/benchmarks/cppbuild/Release/aeron-prefix/tmp/aeron-gitclone.cmake:75 (message):
  Failed to checkout tag: 'head'


CMakeFiles/aeron.dir/build.make:89: recipe for target 'aeron-prefix/src/aeron-stamp/aeron-download' failed
make[2]: *** [aeron-prefix/src/aeron-stamp/aeron-download] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/aeron.dir/all' failed
make[1]: *** [CMakeFiles/aeron.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2

```
OS "Ubuntu 18.04.3 LTS (Bionic Beaver)"
cmake version 3.10.2
```
