### PR TITLE
[Java] Persist and aggregate bechmark results

### DIFF
--- a/scripts/aggregate-results
+++ b/scripts/aggregate-results
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+##
+## Copyright 2015-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+./run-java uk.co.real_logic.benchmarks.rtt.ResultsAggregator "$@"

--- a/src/main/java/uk/co/real_logic/benchmarks/rtt/Configuration.java
+++ b/src/main/java/uk/co/real_logic/benchmarks/rtt/Configuration.java
@@ -20,11 +20,16 @@ import org.agrona.AsciiNumberFormatException;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.NoOpIdleStrategy;
 
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import static java.lang.System.getProperty;
 import static java.lang.reflect.Modifier.isAbstract;
 import static java.lang.reflect.Modifier.isPublic;
+import static java.nio.file.Files.*;
 import static java.util.Objects.requireNonNull;
 import static joptsimple.internal.Strings.isNullOrEmpty;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
@@ -138,6 +143,12 @@ public final class Configuration
      */
     public static final String MESSAGE_TRANSCEIVER_PROP_NAME = "aeron.benchmarks.rtt.messageTransceiver";
 
+    /**
+     * Name of the system property to configure the output directory where histogram files for each run should be
+     * stored. Default value is {@code results} directory created in the current directory.
+     */
+    public static final String OUTPUT_DIRECTORY_PROP_NAME = "aeron.benchmarks.rtt.outputDirectory";
+
     private final int warmUpIterations;
     private final int warmUpNumberOfMessages;
     private final int iterations;
@@ -147,6 +158,7 @@ public final class Configuration
     private final Class<? extends MessageTransceiver> messageTransceiverClass;
     private final IdleStrategy sendIdleStrategy;
     private final IdleStrategy receiveIdleStrategy;
+    private final Path outputDirectory;
 
     private Configuration(final Builder builder)
     {
@@ -160,6 +172,7 @@ public final class Configuration
         this.messageTransceiverClass = validateMessageTransceiverClass(builder.messageTransceiverClass);
         this.sendIdleStrategy = requireNonNull(builder.sendIdleStrategy, "Send IdleStrategy cannot be null");
         this.receiveIdleStrategy = requireNonNull(builder.receiveIdleStrategy, "Receive IdleStrategy cannot be null");
+        this.outputDirectory = validateOutputDirectory(builder.outputDirectory);
     }
 
     /**
@@ -262,6 +275,16 @@ public final class Configuration
         return receiveIdleStrategy;
     }
 
+    /**
+     * Output directory used for storing the historgram files.
+     *
+     * @return output directory.
+     */
+    public Path outputDirectory()
+    {
+        return outputDirectory;
+    }
+
     public String toString()
     {
         return "Configuration{" +
@@ -274,6 +297,7 @@ public final class Configuration
             "\n    messageTransceiverClass=" + messageTransceiverClass.getName() +
             "\n    sendIdleStrategy=" + sendIdleStrategy +
             "\n    receiveIdleStrategy=" + receiveIdleStrategy +
+            "\n    outputDirectory=" + outputDirectory +
             "\n}";
     }
 
@@ -291,6 +315,7 @@ public final class Configuration
         private Class<? extends MessageTransceiver> messageTransceiverClass;
         private IdleStrategy sendIdleStrategy = NoOpIdleStrategy.INSTANCE;
         private IdleStrategy receiveIdleStrategy = NoOpIdleStrategy.INSTANCE;
+        private Path outputDirectory = Paths.get("results");
 
         /**
          * Set the number of warm up iterations.
@@ -402,6 +427,18 @@ public final class Configuration
         }
 
         /**
+         * Set the output directory to store histogram files in.
+         *
+         * @param outputDirectory output directory.
+         * @return this for a fluent API.
+         */
+        public Builder outputDirectory(final Path outputDirectory)
+        {
+            this.outputDirectory = outputDirectory;
+            return this;
+        }
+
+        /**
          * Create a new instance of the {@link Configuration} class from this builder.
          *
          * @return a {@link Configuration} instance
@@ -455,6 +492,11 @@ public final class Configuration
             builder.receiveIdleStrategy(idleStrategyProperty(RECEIVE_IDLE_STRATEGY_PROP_NAME));
         }
 
+        if (isPropertyProvided(OUTPUT_DIRECTORY_PROP_NAME))
+        {
+            builder.outputDirectory(Paths.get(getProperty(OUTPUT_DIRECTORY_PROP_NAME)));
+        }
+
         builder.numberOfMessages(intProperty(MESSAGES_PROP_NAME));
 
         builder.messageTransceiverClass(classProperty(MESSAGE_TRANSCEIVER_PROP_NAME, MessageTransceiver.class));
@@ -497,7 +539,7 @@ public final class Configuration
 
     private static boolean isPropertyProvided(final String propName)
     {
-        return !isNullOrEmpty(System.getProperty(propName));
+        return !isNullOrEmpty(getProperty(propName));
     }
 
     private static int intProperty(final String propName)
@@ -516,7 +558,7 @@ public final class Configuration
 
     private static String getPropertyValue(final String propName)
     {
-        final String value = System.getProperty(propName);
+        final String value = getProperty(propName);
         if (isNullOrEmpty(value))
         {
             throw new IllegalArgumentException("Property '" + propName + "' is required!");
@@ -556,5 +598,37 @@ public final class Configuration
             throw new IllegalArgumentException("Invalid IdleStrategy property '" + propName + "', cause: " +
                 ex.getCause().getMessage());
         }
+    }
+
+    private static Path validateOutputDirectory(final Path outputDirectory)
+    {
+        requireNonNull(outputDirectory, "Output directory cannot be null");
+
+        if (exists(outputDirectory))
+        {
+            if (!isDirectory(outputDirectory))
+            {
+                throw new IllegalArgumentException("Output directory is not a directory: " +
+                    outputDirectory.toAbsolutePath());
+            }
+            if (!isWritable(outputDirectory))
+            {
+                throw new IllegalArgumentException("Output directory is not writeable: " +
+                    outputDirectory.toAbsolutePath());
+            }
+        }
+        else
+        {
+            try
+            {
+                createDirectories(outputDirectory);
+            }
+            catch (final IOException e)
+            {
+                throw new IllegalArgumentException("Failed to create output directory: " + outputDirectory, e);
+            }
+        }
+
+        return outputDirectory.toAbsolutePath();
     }
 }

--- a/src/main/java/uk/co/real_logic/benchmarks/rtt/Configuration.java
+++ b/src/main/java/uk/co/real_logic/benchmarks/rtt/Configuration.java
@@ -149,6 +149,11 @@ public final class Configuration
      */
     public static final String OUTPUT_DIRECTORY_PROP_NAME = "aeron.benchmarks.rtt.outputDirectory";
 
+    /**
+     * Name of the required system property to configure the prefix for the results file.
+     */
+    public static final String OUTPUT_FILE_NAME_PREFIX_PROP_NAME = "aeron.benchmarks.rtt.outputFileNamePrefix";
+
     private final int warmUpIterations;
     private final int warmUpNumberOfMessages;
     private final int iterations;
@@ -159,6 +164,7 @@ public final class Configuration
     private final IdleStrategy sendIdleStrategy;
     private final IdleStrategy receiveIdleStrategy;
     private final Path outputDirectory;
+    private final String outputFileNamePrefix;
 
     private Configuration(final Builder builder)
     {
@@ -173,6 +179,7 @@ public final class Configuration
         this.sendIdleStrategy = requireNonNull(builder.sendIdleStrategy, "Send IdleStrategy cannot be null");
         this.receiveIdleStrategy = requireNonNull(builder.receiveIdleStrategy, "Receive IdleStrategy cannot be null");
         this.outputDirectory = validateOutputDirectory(builder.outputDirectory);
+        outputFileNamePrefix = validateOutputFileName(builder.outputFileNamePrefix);
     }
 
     /**
@@ -276,13 +283,23 @@ public final class Configuration
     }
 
     /**
-     * Output directory used for storing the historgram files.
+     * Output directory used for storing the histogram files.
      *
      * @return output directory.
      */
     public Path outputDirectory()
     {
         return outputDirectory;
+    }
+
+    /**
+     * Output file name prefix used for creating the file name to persist the results histogram.
+     *
+     * @return output file name prefix.
+     */
+    public String outputFileNamePrefix()
+    {
+        return outputFileNamePrefix;
     }
 
     public String toString()
@@ -298,6 +315,7 @@ public final class Configuration
             "\n    sendIdleStrategy=" + sendIdleStrategy +
             "\n    receiveIdleStrategy=" + receiveIdleStrategy +
             "\n    outputDirectory=" + outputDirectory +
+            "\n    outputFileNamePrefix=" + outputFileNamePrefix +
             "\n}";
     }
 
@@ -316,6 +334,7 @@ public final class Configuration
         private IdleStrategy sendIdleStrategy = NoOpIdleStrategy.INSTANCE;
         private IdleStrategy receiveIdleStrategy = NoOpIdleStrategy.INSTANCE;
         private Path outputDirectory = Paths.get("results");
+        private String outputFileNamePrefix;
 
         /**
          * Set the number of warm up iterations.
@@ -439,6 +458,18 @@ public final class Configuration
         }
 
         /**
+         * Set the output file name prefix.
+         *
+         * @param outputFileNamePrefix file name prefix.
+         * @return this for a fluent API.
+         */
+        public Builder outputFileNamePrefix(final String outputFileNamePrefix)
+        {
+            this.outputFileNamePrefix = outputFileNamePrefix;
+            return this;
+        }
+
+        /**
          * Create a new instance of the {@link Configuration} class from this builder.
          *
          * @return a {@link Configuration} instance
@@ -500,6 +531,8 @@ public final class Configuration
         builder.numberOfMessages(intProperty(MESSAGES_PROP_NAME));
 
         builder.messageTransceiverClass(classProperty(MESSAGE_TRANSCEIVER_PROP_NAME, MessageTransceiver.class));
+
+        builder.outputFileNamePrefix(getProperty(OUTPUT_FILE_NAME_PREFIX_PROP_NAME));
 
         return builder.build();
     }
@@ -631,4 +664,15 @@ public final class Configuration
 
         return outputDirectory.toAbsolutePath();
     }
+
+    private static String validateOutputFileName(final String outputFileNamePrefix)
+    {
+        final String prefix = requireNonNull(outputFileNamePrefix, "Output file name prefix cannot be null").trim();
+        if (prefix.isEmpty())
+        {
+            throw new IllegalArgumentException("Output file name prefix cannot be empty!");
+        }
+        return prefix;
+    }
+
 }

--- a/src/main/java/uk/co/real_logic/benchmarks/rtt/LoadTestRig.java
+++ b/src/main/java/uk/co/real_logic/benchmarks/rtt/LoadTestRig.java
@@ -15,7 +15,6 @@
  */
 package uk.co.real_logic.benchmarks.rtt;
 
-import org.HdrHistogram.Histogram;
 import org.agrona.LangUtil;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.IdleStrategy;
@@ -31,7 +30,6 @@ import static java.lang.Math.min;
 import static java.lang.Math.round;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.runAsync;
-import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -47,7 +45,7 @@ public final class LoadTestRig
     private final MessageTransceiver messageTransceiver;
     private final NanoClock clock;
     private final PrintStream out;
-    private final Histogram histogram;
+    private final RttHistogram histogram;
     private final AtomicLong sentMessages;
     private final AtomicLong receivedMessages;
 
@@ -58,7 +56,7 @@ public final class LoadTestRig
             requireNonNull(configuration.messageTransceiverClass());
         clock = SystemNanoClock.INSTANCE;
         out = System.out;
-        histogram = new Histogram(HOURS.toNanos(1), 3);
+        histogram = new RttHistogram();
         sentMessages = new AtomicLong();
         receivedMessages = new AtomicLong();
         try
@@ -85,7 +83,7 @@ public final class LoadTestRig
         final Configuration configuration,
         final NanoClock clock,
         final PrintStream out,
-        final Histogram histogram,
+        final RttHistogram histogram,
         final MessageTransceiver messageTransceiver,
         final AtomicLong sentMessages,
         final AtomicLong receivedMessages)
@@ -146,6 +144,8 @@ public final class LoadTestRig
                     "total but managed to send only %,d messages!%n", expectedTotalNumberOfMessages,
                     sentMessages.get());
             }
+
+            histogram.saveToFile(configuration.outputDirectory(), configuration.outputFileNamePrefix());
         }
         finally
         {

--- a/src/main/java/uk/co/real_logic/benchmarks/rtt/ResultsAggregator.java
+++ b/src/main/java/uk/co/real_logic/benchmarks/rtt/ResultsAggregator.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.rtt;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogReader;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static java.nio.file.Files.*;
+import static java.util.stream.Collectors.groupingBy;
+import static uk.co.real_logic.benchmarks.rtt.RttHistogram.*;
+import static uk.co.real_logic.benchmarks.rtt.RttHistogram.AGGREGATE_FILE_SUFFIX;
+import static uk.co.real_logic.benchmarks.rtt.RttHistogram.FILE_EXTENSION;
+
+public final class ResultsAggregator
+{
+    private final Path directory;
+    private final double outputValueUnitScalingRatio;
+
+    public ResultsAggregator(final Path directory, final double outputValueUnitScalingRatio)
+    {
+        if (!exists(directory))
+        {
+            throw new IllegalArgumentException("Directory " + directory.toAbsolutePath() + " does not exist!");
+        }
+
+        if (!isDirectory(directory))
+        {
+            throw new IllegalArgumentException(directory.toAbsolutePath() + " is not a directory!");
+        }
+
+        if (Double.isNaN(outputValueUnitScalingRatio) || Double.compare(outputValueUnitScalingRatio, 0.0) <= 0)
+        {
+            throw new IllegalArgumentException(
+                "Output value scale ratio must a positive number, got: " + outputValueUnitScalingRatio);
+        }
+
+        this.directory = directory;
+        this.outputValueUnitScalingRatio = outputValueUnitScalingRatio;
+    }
+
+    public void run() throws IOException
+    {
+        final Map<String, List<Path>> byPrefix = walk(directory)
+            .filter(path ->
+            {
+                if (!isRegularFile(path))
+                {
+                    return false;
+                }
+                final String fileName = path.getFileName().toString();
+                return fileName.endsWith(FILE_EXTENSION) && !fileName.endsWith(AGGREGATE_FILE_SUFFIX);
+            })
+            .collect(groupingBy(file ->
+            {
+                final String fileName = file.getFileName().toString();
+                return fileName.substring(0, fileName.lastIndexOf('-'));
+            }));
+
+        for (final Entry<String, List<Path>> e : byPrefix.entrySet())
+        {
+            final Histogram aggregate = aggregateHistograms(e);
+            saveToFile(aggregate, outputValueUnitScalingRatio, directory.resolve(e.getKey() + AGGREGATE_FILE_SUFFIX));
+        }
+    }
+
+    private Histogram aggregateHistograms(final Entry<String, List<Path>> e) throws FileNotFoundException
+    {
+        Histogram aggregate = null;
+        for (final Path file : e.getValue())
+        {
+            final HistogramLogReader logReader = new HistogramLogReader(file.toFile());
+            try
+            {
+                while (logReader.hasNext())
+                {
+                    final Histogram histo = (Histogram)logReader.nextIntervalHistogram();
+                    if (null == aggregate)
+                    {
+                        aggregate = histo;
+                    }
+                    else
+                    {
+                        aggregate.add(histo);
+                    }
+                }
+            }
+            finally
+            {
+                logReader.close();
+            }
+        }
+
+        return aggregate;
+    }
+
+    public static void main(final String[] args) throws IOException
+    {
+        if (args.length < 1 || args.length > 2)
+        {
+            printHelp();
+            System.exit(-1);
+        }
+
+        final Path directory = Paths.get(args[0]);
+        final ResultsAggregator resultsAggregator =
+            new ResultsAggregator(directory, args.length == 2 ? Double.parseDouble(args[1]) : 1.0);
+        resultsAggregator.run();
+    }
+
+    private static void printHelp()
+    {
+        System.out.println("Usage: <input-dir> [outputValueUnitScalingRatio] - aggregates multiple histogram files");
+        System.out.println("  from the `input-dir` into a single file grouping them by a common prefix.");
+        System.out.println("  For example if the `input-dir` contains files `my-0.hdr`, `my-6.hdr` and `other-3.hdr`");
+        System.out.println("  the result of executing the aggregator will be two new files in the same directory,");
+        System.out.println("  i.e. `my-combined.hdr` (combination of the `my-0.hdr` and `my-6.hdr`) and");
+        System.out.println("  `other-combined.hdr` (contains the `other-0.hdr` histogram).");
+        System.out.println();
+        System.out.println("  Input arguments:");
+        System.out.println("  `input-dir` - is the directory containing results files to be aggregated");
+        System.out.println("  `outputValueUnitScalingRatio` - is the scaling factor by which to divide histogram");
+        System.out.println("  recorded values units in output.");
+        System.out.println("  Default value is 1.0, i.e. the output will be in nanoseconds.");
+        System.out.println("  For example setting `outputValueUnitScalingRatio` to 1000.0 will change the output");
+        System.out.println("  to be in microseconds.");
+    }
+}

--- a/src/main/java/uk/co/real_logic/benchmarks/rtt/RttHistogram.java
+++ b/src/main/java/uk/co/real_logic/benchmarks/rtt/RttHistogram.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.rtt;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+import static java.nio.file.Files.find;
+import static java.nio.file.Files.isRegularFile;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static org.agrona.AsciiEncoding.parseIntAscii;
+
+final class RttHistogram
+{
+    public static final String FILE_EXTENSION = ".hdr";
+
+    private final Histogram histogram;
+
+    RttHistogram()
+    {
+        this(new Histogram(HOURS.toNanos(1), 3));
+    }
+
+    RttHistogram(final Histogram histogram)
+    {
+        this.histogram = histogram;
+    }
+
+    /**
+     * Discard recorder values.
+     */
+    public void reset()
+    {
+        histogram.reset();
+    }
+
+    /**
+     * Record a value in the histogram.
+     *
+     * @param value RTT value to be recorded.
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
+     */
+    public void recordValue(final long value)
+    {
+        histogram.recordValue(value);
+    }
+
+    /**
+     * Produce textual representation of the value distribution of histogram data by percentile. The distribution is
+     * output with exponentially increasing resolution, with each exponentially decreasing half-distance containing
+     * five (5) percentile reporting tick points.
+     *
+     * @param printStream                 stream into which the distribution will be output.
+     * @param outputValueUnitScalingRatio the scaling factor by which to divide histogram recorded values units in
+     *                                    output.
+     */
+    public void outputPercentileDistribution(final PrintStream printStream, final double outputValueUnitScalingRatio)
+    {
+        histogram.outputPercentileDistribution(printStream, outputValueUnitScalingRatio);
+    }
+
+    /**
+     * Save histogram into a file on disc. Uses provided {@code namePrefix} and appending an <em>index</em> to ensure
+     * unique name, i.e. {@code namePrefix_index.hdr}. For example the first file with a given prefix
+     * will be stored under index zero (e.g. {@code my-file_0.hdr}) and the fifth under index number four
+     * (e.g. {@code my-file_4.hdr}).
+     *
+     * @param outputDirectory output directory where files should be stored.
+     * @param namePrefix      name prefix to use when creating a file.
+     * @return created file.
+     * @throws NullPointerException     if {@code null == outputDirectory || null == namePrefix}.
+     * @throws IllegalArgumentException if {@code namePrefix} is blank.
+     * @throws IOException              if IO error occurs.
+     */
+    public Path saveToFile(final Path outputDirectory, final String namePrefix) throws IOException
+    {
+        requireNonNull(outputDirectory);
+
+        final String prefix = namePrefix.trim();
+        if (prefix.isEmpty())
+        {
+            throw new IllegalArgumentException("Name prefix cannot be blank!");
+        }
+
+        final String fileNamePrefix = prefix + "-";
+        final int index = find(outputDirectory, 1, (file, attrs) ->
+        {
+            if (!isRegularFile(file))
+            {
+                return false;
+            }
+            final String fileName = file.getFileName().toString();
+            return fileName.endsWith(FILE_EXTENSION) && fileName.startsWith(fileNamePrefix);
+        }).mapToInt(file ->
+        {
+            final String fileName = file.getFileName().toString();
+            final int indexLength = fileName.length() - FILE_EXTENSION.length() - fileNamePrefix.length();
+            return parseIntAscii(fileName, fileNamePrefix.length(), indexLength);
+        }).max().orElse(-1) + 1;
+
+        final Path file = outputDirectory.resolve(fileNamePrefix + index + FILE_EXTENSION);
+        final HistogramLogWriter logWriter = new HistogramLogWriter(file.toFile());
+        try
+        {
+            logWriter.outputIntervalHistogram(
+                histogram.getStartTimeStamp() / 1000.0, histogram.getEndTimeStamp() / 1000.0, histogram, 1.0);
+        }
+        finally
+        {
+            logWriter.close();
+        }
+        return file;
+    }
+}

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/ResultsAggregatorTest.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/ResultsAggregatorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.rtt;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogReader;
+import org.HdrHistogram.HistogramLogWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.util.Arrays.sort;
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.co.real_logic.benchmarks.rtt.RttHistogram.AGGREGATE_FILE_SUFFIX;
+
+class ResultsAggregatorTest
+{
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void throwsNullPointerExceptionIfDirectoryIsNull()
+    {
+        assertThrows(NullPointerException.class, () -> new ResultsAggregator(null, 1));
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionIfDirectoryDoesNotExist()
+    {
+        final Path dir = tempDir.resolve("non-existing");
+
+        final IllegalArgumentException exception =
+            assertThrows(IllegalArgumentException.class, () -> new ResultsAggregator(dir, 1));
+
+        assertEquals("Directory " + dir + " does not exist!", exception.getMessage());
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionIfDirectoryIsNotADirectory() throws IOException
+    {
+        final Path file = Files.createFile(tempDir.resolve("one.txt"));
+
+        final IllegalArgumentException exception =
+            assertThrows(IllegalArgumentException.class, () -> new ResultsAggregator(file, 1));
+
+        assertEquals(file + " is not a directory!", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = { -1.0, 0.0, Double.NaN })
+    void throwsIllegalArgumentExceptionIfOutputValueUnitScalingRatioIsInvalid(final double outputValueUnitScalingRatio)
+    {
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> new ResultsAggregator(tempDir, outputValueUnitScalingRatio));
+
+        assertEquals("Output value scale ratio must a positive number, got: " + outputValueUnitScalingRatio,
+            exception.getMessage());
+    }
+
+    @Test
+    void emptyDirectory() throws IOException
+    {
+        final ResultsAggregator aggregator = new ResultsAggregator(tempDir, 1);
+
+        aggregator.run();
+
+        assertArrayEquals(new File[0], tempDir.toFile().listFiles());
+    }
+
+    @Test
+    void directoryContainsNonHdrFiles() throws IOException
+    {
+        final Path otherFile = Files.createFile(tempDir.resolve("other.txt"));
+
+        final ResultsAggregator aggregator = new ResultsAggregator(tempDir, 1);
+
+        aggregator.run();
+
+        assertArrayEquals(new File[]{ otherFile.toFile() }, tempDir.toFile().listFiles());
+    }
+
+    @Test
+    void multipleHistogramFiles() throws IOException
+    {
+        saveToDisc("my-5.hdr", createHistogram(10, 25, 100, 555, 777, 999));
+        saveToDisc("my-0.hdr", createHistogram(2, 4, 555555, 1232343));
+        saveToDisc("my-combined.hdr", createHistogram(3, 4, 11, 1, 1, 22));
+        saveToDisc("other-78.hdr", createHistogram(1, 45, 200));
+        saveToDisc("hidden-4.ccc", createHistogram(0, 0, 1, 2, 3, 4, 5, 6));
+        saveToDisc("hidden-6.ccc", createHistogram(0, 0, 6, 6, 0));
+
+        final ResultsAggregator aggregator = new ResultsAggregator(tempDir, 1);
+
+        aggregator.run();
+
+        final String[] aggregateFiles = tempDir.toFile().list((dir, name) -> name.endsWith(AGGREGATE_FILE_SUFFIX));
+        sort(aggregateFiles);
+        assertArrayEquals(new String[]{ "my-combined.hdr", "other-combined.hdr" },
+            aggregateFiles);
+        assertEquals(createHistogram(2, 25, 100, 555, 777, 999, 555555, 1232343),
+            loadFromDisc("my-combined.hdr"));
+        assertEquals(createHistogram(1, 45, 200), loadFromDisc("other-combined.hdr"));
+    }
+
+    private Histogram createHistogram(final long startTimeMs, final long endTimeMs, final long... values)
+    {
+        final Histogram histogram = new Histogram(3);
+        histogram.setStartTimeStamp(startTimeMs);
+        histogram.setEndTimeStamp(endTimeMs);
+
+        for (final long value : values)
+        {
+            histogram.recordValue(value);
+        }
+        return histogram;
+    }
+
+    private void saveToDisc(final String fileName, final Histogram histogram) throws FileNotFoundException
+    {
+        final HistogramLogWriter logWriter = new HistogramLogWriter(tempDir.resolve(fileName).toFile());
+        try
+        {
+            logWriter.outputIntervalHistogram(
+                histogram.getStartTimeStamp() / 1000.0, histogram.getEndTimeStamp() / 1000.0, histogram, 1);
+        }
+        finally
+        {
+            logWriter.close();
+        }
+    }
+
+    private Histogram loadFromDisc(final String fileName) throws FileNotFoundException
+    {
+        final HistogramLogReader logReader = new HistogramLogReader(tempDir.resolve(fileName).toFile());
+        try
+        {
+            return (Histogram)logReader.nextIntervalHistogram();
+        }
+        finally
+        {
+            logReader.close();
+        }
+    }
+
+}

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/RttHistogramTest.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/RttHistogramTest.java
@@ -1,0 +1,158 @@
+package uk.co.real_logic.benchmarks.rtt;
+
+import org.HdrHistogram.EncodableHistogram;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RttHistogramTest
+{
+    private final Histogram histogram = mock(Histogram.class);
+    private final RttHistogram rttHistogram = new RttHistogram(histogram);
+
+    @Test
+    void reset()
+    {
+        rttHistogram.reset();
+
+        verify(histogram).reset();
+        verifyNoMoreInteractions(histogram);
+    }
+
+    @Test
+    void recordValue()
+    {
+        final long value = 131;
+
+        rttHistogram.recordValue(value);
+
+        verify(histogram).recordValue(value);
+        verifyNoMoreInteractions(histogram);
+    }
+
+    @Test
+    void outputPercentileDistribution()
+    {
+        final PrintStream out = System.out;
+        final double scaleRatio = -2.5;
+
+        rttHistogram.outputPercentileDistribution(out, scaleRatio);
+
+        verify(histogram).outputPercentileDistribution(out, scaleRatio);
+        verifyNoMoreInteractions(histogram);
+    }
+
+    @Test
+    void saveToFileThrowsNullPointerExceptionIfOutputDirectoryIsNull()
+    {
+        assertThrows(NullPointerException.class, () -> rttHistogram.saveToFile(null, "my-file"));
+    }
+
+    @Test
+    void saveToFileThrowsNullPointerExceptionIfNamePrefixIsNull(final @TempDir Path tempDir)
+    {
+        assertThrows(NullPointerException.class, () -> rttHistogram.saveToFile(tempDir, null));
+    }
+
+    @Test
+    void saveToFileThrowsIllegalArgumentExceptionIfNamePrefixIsEmpty(final @TempDir Path tempDir)
+    {
+        assertThrows(IllegalArgumentException.class, () -> rttHistogram.saveToFile(tempDir, ""));
+    }
+
+    @Test
+    void saveToFileThrowsIllegalArgumentExceptionIfNamePrefixIsBlank(final @TempDir Path tempDir)
+    {
+        assertThrows(IllegalArgumentException.class, () -> rttHistogram.saveToFile(tempDir, " \t  \n  "));
+    }
+
+    @Test
+    void saveToFileThrowsIOExceptionIfSaveFails(final @TempDir Path tempDir) throws IOException
+    {
+        final Path rootFile = Files.createFile(tempDir.resolve("my.txt"));
+
+        final Histogram histogram = new Histogram(2);
+        histogram.recordValue(2);
+        histogram.recordValue(4);
+
+        final RttHistogram rttHistogram = new RttHistogram(histogram.copy());
+
+        assertThrows(IOException.class, () -> rttHistogram.saveToFile(rootFile, "ignore"));
+    }
+
+    @Test
+    void saveToFileCreatesNewFileWithIndexZero(final @TempDir Path tempDir) throws IOException
+    {
+        Files.createFile(tempDir.resolve("another-one-13.hdr"));
+
+        final Histogram histogram = new Histogram(3);
+        histogram.setStartTimeStamp(123456789);
+        histogram.setEndTimeStamp(987654321);
+        histogram.recordValue(100);
+        histogram.recordValue(1000);
+        histogram.recordValue(250);
+
+        final RttHistogram rttHistogram = new RttHistogram(histogram.copy());
+
+        final Path file = rttHistogram.saveToFile(tempDir, "test-histogram");
+
+        assertNotNull(file);
+        assertTrue(Files.exists(file));
+        assertEquals("test-histogram-0.hdr", file.getFileName().toString());
+        final Histogram savedHistogram = readHistogram(file);
+        assertEquals(histogram, savedHistogram);
+        assertEquals(histogram.getStartTimeStamp(), savedHistogram.getStartTimeStamp());
+        assertEquals(histogram.getEndTimeStamp(), savedHistogram.getEndTimeStamp());
+    }
+
+    @Test
+    void saveToFileCreatesNewFileByIncrementExistingMaxIndex(final @TempDir Path tempDir) throws IOException
+    {
+        Files.createFile(tempDir.resolve("another_one-13.hdr"));
+
+        final Histogram histogram = new Histogram(2);
+        histogram.recordValue(2);
+        histogram.recordValue(4);
+
+        final RttHistogram rttHistogram = new RttHistogram(histogram.copy());
+
+        final Path file = rttHistogram.saveToFile(tempDir, "another_one");
+
+        assertNotNull(file);
+        assertTrue(Files.exists(file));
+        assertEquals("another_one-14.hdr", file.getFileName().toString());
+        final Histogram savedHistogram = readHistogram(file);
+        assertEquals(histogram, savedHistogram);
+    }
+
+    private Histogram readHistogram(final Path file) throws FileNotFoundException
+    {
+        final List<EncodableHistogram> histograms = new ArrayList<>();
+        final HistogramLogReader logReader = new HistogramLogReader(file.toFile());
+        try
+        {
+            while (logReader.hasNext())
+            {
+                histograms.add(logReader.nextIntervalHistogram());
+            }
+        }
+        finally
+        {
+            logReader.close();
+        }
+        assertEquals(1, histograms.size());
+        return (Histogram)histograms.get(0);
+    }
+}

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/RttHistogramTest.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/RttHistogramTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.co.real_logic.benchmarks.rtt;
 
 import org.HdrHistogram.EncodableHistogram;
@@ -16,6 +31,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static uk.co.real_logic.benchmarks.rtt.RttHistogram.AGGREGATE_FILE_SUFFIX;
 
 class RttHistogramTest
 {
@@ -121,6 +137,7 @@ class RttHistogramTest
     void saveToFileCreatesNewFileByIncrementExistingMaxIndex(final @TempDir Path tempDir) throws IOException
     {
         Files.createFile(tempDir.resolve("another_one-13.hdr"));
+        Files.createFile(tempDir.resolve("another_one" + AGGREGATE_FILE_SUFFIX));
 
         final Histogram histogram = new Histogram(2);
         histogram.recordValue(2);

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/aeron/AbstractTest.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/aeron/AbstractTest.java
@@ -22,10 +22,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import uk.co.real_logic.benchmarks.rtt.Configuration;
 import uk.co.real_logic.benchmarks.rtt.MessageRecorder;
 import uk.co.real_logic.benchmarks.rtt.MessageTransceiver;
 
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -57,32 +59,35 @@ abstract class AbstractTest<DRIVER extends AutoCloseable,
 
     @Timeout(30)
     @Test
-    void messageLength16bytes() throws Exception
+    void messageLength16bytes(final @TempDir Path tempDir) throws Exception
     {
-        test(10_000, MIN_MESSAGE_LENGTH, 10);
+        test(10_000, MIN_MESSAGE_LENGTH, 10, tempDir);
     }
 
     @Timeout(30)
     @Test
-    void messageLength200bytes() throws Exception
+    void messageLength200bytes(final @TempDir Path tempDir) throws Exception
     {
-        test(1000, 200, 5);
+        test(1000, 200, 5, tempDir);
     }
 
     @Timeout(30)
     @Test
-    void messageLength32KB() throws Exception
+    void messageLength32KB(final @TempDir Path tempDir) throws Exception
     {
-        test(100, 32 * 1024, 1);
+        test(100, 32 * 1024, 1, tempDir);
     }
 
     @SuppressWarnings("MethodLength")
-    private void test(final int messages, final int messageLength, final int burstSize) throws Exception
+    private void test(
+        final int messages, final int messageLength, final int burstSize, final Path tempDir) throws Exception
     {
         final Configuration configuration = new Configuration.Builder()
             .numberOfMessages(messages)
             .messageLength(messageLength)
             .messageTransceiverClass(messageTransceiverClass())
+            .outputDirectory(tempDir)
+            .outputFileNamePrefix(getClass().getSimpleName() + "-results")
             .build();
 
         final AtomicReference<Throwable> error = new AtomicReference<>();


### PR DESCRIPTION
Add two new configuration options:
- `aeron.benchmarks.rtt.outputDirectory` - defines an output directory to store the histogram files. Defaults to `results` in a current directory.
- `aeron.benchmarks.rtt.outputFileNamePrefix` - required property to set file name prefix for the histogram file.

Every run of the `LoadTestRig` will generate a results file in the output directory by adding a unique index to the file. For example if the prefix is set to `my-tests` then the first file will be created with the name `my-tests-0.hdr`, the second as `my-tests-1.hdr` and so on.

There is also an aggregator to combine multiple results into a single file. Aggregator can be either invoked programmatically `uk.co.real_logic.benchmarks.rtt.ResultsAggregator` or via script `aggregate-results`. The aggregator accepts two options:
- input directory
- output value unit scaling ratio - the scaling factor by which to divide histogram recorded values units in the output file. Default value is `1.0` meaning that the original nanosecond resolution will be preserved.