### PR TITLE
[Java] Compute output file name prefix from the configuration

### DIFF
--- a/src/test/java/org/other/benchmark/impl/MessageTransceiverFromAnotherPackage.java
+++ b/src/test/java/org/other/benchmark/impl/MessageTransceiverFromAnotherPackage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.other.benchmark.impl;
+
+import uk.co.real_logic.benchmarks.rtt.Configuration;
+import uk.co.real_logic.benchmarks.rtt.MessageRecorder;
+import uk.co.real_logic.benchmarks.rtt.MessageTransceiver;
+
+public class MessageTransceiverFromAnotherPackage extends MessageTransceiver
+{
+    public MessageTransceiverFromAnotherPackage(final MessageRecorder messageRecorder)
+    {
+        super(messageRecorder);
+    }
+
+    public void init(final Configuration configuration) throws Exception
+    {
+    }
+
+    public void destroy() throws Exception
+    {
+    }
+
+    public int send(final int numberOfMessages, final int messageLength, final long timestamp, final long checksum)
+    {
+        return 0;
+    }
+
+    public void receive()
+    {
+    }
+}

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/LoadTestRigTest.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/LoadTestRigTest.java
@@ -58,7 +58,6 @@ class LoadTestRigTest
             .sendIdleStrategy(senderIdleStrategy)
             .receiveIdleStrategy(receiverIdleStrategy)
             .outputDirectory(tempDir)
-            .outputFileNamePrefix("test-results")
             .build();
     }
 
@@ -173,7 +172,6 @@ class LoadTestRigTest
             .messageLength(24)
             .messageTransceiverClass(InMemoryMessageTransceiver.class)
             .outputDirectory(tempDir)
-            .outputFileNamePrefix("test")
             .build();
 
         final LoadTestRig loadTestRig = new LoadTestRig(
@@ -217,7 +215,6 @@ class LoadTestRigTest
             .messageLength(100)
             .messageTransceiverClass(InMemoryMessageTransceiver.class)
             .outputDirectory(tempDir)
-            .outputFileNamePrefix("test")
             .build();
 
         final LoadTestRig loadTestRig = new LoadTestRig(
@@ -256,7 +253,6 @@ class LoadTestRigTest
             .warmUpIterations(0)
             .messageTransceiverClass(InMemoryMessageTransceiver.class)
             .outputDirectory(tempDir)
-            .outputFileNamePrefix("test")
             .build();
         final LoadTestRig testRig = new LoadTestRig(configuration);
 

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/aeron/AbstractTest.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/aeron/AbstractTest.java
@@ -87,7 +87,6 @@ abstract class AbstractTest<DRIVER extends AutoCloseable,
             .messageLength(messageLength)
             .messageTransceiverClass(messageTransceiverClass())
             .outputDirectory(tempDir)
-            .outputFileNamePrefix(getClass().getSimpleName() + "-results")
             .build();
 
         final AtomicReference<Throwable> error = new AtomicReference<>();

--- a/src/test/java/uk/co/real_logic/benchmarks/rtt/nested/NestedMessageTransceiver.java
+++ b/src/test/java/uk/co/real_logic/benchmarks/rtt/nested/NestedMessageTransceiver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.rtt.nested;
+
+import uk.co.real_logic.benchmarks.rtt.Configuration;
+import uk.co.real_logic.benchmarks.rtt.MessageRecorder;
+import uk.co.real_logic.benchmarks.rtt.MessageTransceiver;
+
+public class NestedMessageTransceiver extends MessageTransceiver
+{
+    public NestedMessageTransceiver(final MessageRecorder messageRecorder)
+    {
+        super(messageRecorder);
+    }
+
+    public void init(final Configuration configuration) throws Exception
+    {
+    }
+
+    public void destroy() throws Exception
+    {
+    }
+
+    public int send(final int numberOfMessages, final int messageLength, final long timestamp, final long checksum)
+    {
+        return 0;
+    }
+
+    public void receive()
+    {
+    }
+}


### PR DESCRIPTION
Output file name prefix is computed from the configuration values using the following scheme `$className_$numberOfMessages_$batchSize_$messageLength`, where:
- `$className` - is a shortened version of the `MessageTransceiver` class name, i.e. a common prefix `uk.co.real_logic.benchmarks.rtt.` is removed from the fully qualified class name
- `$numberOfMessages` - is the number of messages
- `$batchSize` - is the batch size
- `$messageLength` - is the message length