### PR TITLE
[Java] Add remote benchmarks for gRPC

### DIFF
--- a/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/BlockingMessageTrasceiver.java
+++ b/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/BlockingMessageTrasceiver.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import uk.co.real_logic.benchmarks.remote.Configuration;
+import uk.co.real_logic.benchmarks.remote.MessageRecorder;
+import uk.co.real_logic.benchmarks.remote.MessageTransceiver;
+import uk.co.real_logic.benchmarks.grpc.remote.EchoBenchmarksGrpc.EchoBenchmarksBlockingStub;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.protobuf.ByteString.copyFrom;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static uk.co.real_logic.benchmarks.remote.Configuration.MIN_MESSAGE_LENGTH;
+import static uk.co.real_logic.benchmarks.grpc.remote.GrpcConfig.getServerChannel;
+
+public class BlockingMessageTrasceiver extends MessageTransceiver
+{
+    private ManagedChannel serverChannel;
+    private EchoBenchmarksBlockingStub blockingClient;
+    private EchoMessage.Builder messageBuilder;
+    private ByteString payload;
+
+    public BlockingMessageTrasceiver(final MessageRecorder messageRecorder)
+    {
+        super(messageRecorder);
+    }
+
+    public void init(final Configuration configuration) throws Exception
+    {
+        serverChannel = getServerChannel();
+        blockingClient = EchoBenchmarksGrpc.newBlockingStub(serverChannel);
+
+        messageBuilder = EchoMessage.newBuilder();
+        final int payloadLength = configuration.messageLength() - MIN_MESSAGE_LENGTH - 4 /* array length field */;
+        if (payloadLength <= 0)
+        {
+            payload = ByteString.EMPTY;
+        }
+        else
+        {
+            final byte[] bytes = new byte[payloadLength];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            payload = copyFrom(bytes);
+        }
+    }
+
+    public void destroy() throws Exception
+    {
+        blockingClient = null;
+        serverChannel.shutdown().awaitTermination(1, MINUTES);
+    }
+
+    public int send(final int numberOfMessages, final int length, final long timestamp, final long checksum)
+    {
+        final EchoBenchmarksBlockingStub blockingClient = this.blockingClient;
+        final EchoMessage.Builder messageBuilder = this.messageBuilder;
+        final ByteString payload = this.payload;
+
+        for (int i = 0; i < numberOfMessages; i++)
+        {
+            final EchoMessage request = messageBuilder
+                .setTimestamp(timestamp)
+                .setPayload(payload)
+                .setChecksum(checksum)
+                .build();
+
+            final EchoMessage response = blockingClient.echo(request);
+
+            onMessageReceived(response.getTimestamp(), response.getChecksum());
+        }
+
+        return numberOfMessages;
+    }
+
+    public void receive()
+    {
+    }
+}

--- a/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/EchoServer.java
+++ b/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/EchoServer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import io.grpc.Server;
+import org.agrona.SystemUtil;
+import org.agrona.concurrent.ShutdownSignalBarrier;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+
+import static io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder.forAddress;
+
+public class EchoServer implements AutoCloseable
+{
+    private final Server server;
+
+    public EchoServer(final SocketAddress serverAddress)
+    {
+        server = forAddress(serverAddress).addService(new EchoService()).build();
+    }
+
+    public void start() throws IOException
+    {
+        server.start();
+        System.out.println("Server started, listening on: " + server.getListenSockets());
+    }
+
+    public void close() throws Exception
+    {
+        System.out.println("Shutting down server...");
+        server.shutdownNow();
+        server.awaitTermination();
+    }
+
+    public static void main(final String[] args) throws Exception
+    {
+        SystemUtil.loadPropertiesFiles(args);
+
+        try (EchoServer server = new EchoServer(GrpcConfig.getServerAddress()))
+        {
+            server.start();
+
+            new ShutdownSignalBarrier().await();
+        }
+    }
+
+}

--- a/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/EchoService.java
+++ b/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/EchoService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import io.grpc.stub.StreamObserver;
+import org.agrona.LangUtil;
+
+class EchoService extends EchoBenchmarksGrpc.EchoBenchmarksImplBase
+{
+    public void echo(final EchoMessage request, final StreamObserver<EchoMessage> responseObserver)
+    {
+        responseObserver.onNext(request);
+        responseObserver.onCompleted();
+    }
+
+    public StreamObserver<EchoMessage> echoStream(final StreamObserver<EchoMessage> responseObserver)
+    {
+        return new StreamObserver<EchoMessage>()
+        {
+            public void onNext(final EchoMessage message)
+            {
+                responseObserver.onNext(message);
+            }
+
+            public void onError(final Throwable t)
+            {
+                t.printStackTrace();
+                responseObserver.onCompleted();
+                LangUtil.rethrowUnchecked(t);
+            }
+
+            public void onCompleted()
+            {
+                responseObserver.onCompleted();
+            }
+        };
+    }
+}

--- a/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/GrpcConfig.java
+++ b/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/GrpcConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import io.grpc.ManagedChannel;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import static io.grpc.ManagedChannelBuilder.forAddress;
+import static java.lang.Integer.getInteger;
+import static java.lang.System.getProperty;
+
+final class GrpcConfig
+{
+    public static final String SERVER_HOST = "uk.co.real_logic.benchmarks.grpc.remote.server.host";
+    public static final String SERVER_PORT = "uk.co.real_logic.benchmarks.grpc.remote.server.port";
+
+    private GrpcConfig()
+    {
+    }
+
+    public static ManagedChannel getServerChannel()
+    {
+        return forAddress(getServerHost(), getServerPort()).usePlaintext().build();
+    }
+
+    public static SocketAddress getServerAddress()
+    {
+        return new InetSocketAddress(getServerHost(), getServerPort());
+    }
+
+    private static String getServerHost()
+    {
+        final String host = getProperty(SERVER_HOST);
+        return null != host ? host : "127.0.0.1";
+    }
+
+    private static int getServerPort()
+    {
+        return getInteger(SERVER_PORT, 13400);
+    }
+}

--- a/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/StreamingMessageTrasceiver.java
+++ b/benchmarks-grpc/src/main/java/uk/co/real_logic/benchmarks/grpc/remote/StreamingMessageTrasceiver.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.agrona.LangUtil;
+import uk.co.real_logic.benchmarks.remote.Configuration;
+import uk.co.real_logic.benchmarks.remote.MessageRecorder;
+import uk.co.real_logic.benchmarks.remote.MessageTransceiver;
+import uk.co.real_logic.benchmarks.grpc.remote.EchoBenchmarksGrpc.EchoBenchmarksStub;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.protobuf.ByteString.copyFrom;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static uk.co.real_logic.benchmarks.grpc.remote.GrpcConfig.getServerChannel;
+import static uk.co.real_logic.benchmarks.remote.Configuration.MIN_MESSAGE_LENGTH;
+
+public class StreamingMessageTrasceiver extends MessageTransceiver
+{
+    private ManagedChannel serverChannel;
+    private EchoBenchmarksStub asyncClient;
+    private ClientCallStreamObserver<EchoMessage> requestObserver;
+    private EchoMessage.Builder messageBuilder;
+    private ByteString payload;
+
+    public StreamingMessageTrasceiver(final MessageRecorder messageRecorder)
+    {
+        super(messageRecorder);
+    }
+
+    public void init(final Configuration configuration) throws Exception
+    {
+        serverChannel = getServerChannel();
+        asyncClient = EchoBenchmarksGrpc.newStub(serverChannel);
+
+        final StreamObserver<EchoMessage> responseObserver = new StreamObserver<EchoMessage>()
+        {
+            public void onNext(final EchoMessage response)
+            {
+                onMessageReceived(response.getTimestamp(), response.getChecksum());
+            }
+
+            public void onError(final Throwable t)
+            {
+                t.printStackTrace();
+                LangUtil.rethrowUnchecked(t);
+            }
+
+            public void onCompleted()
+            {
+            }
+        };
+
+        requestObserver = (ClientCallStreamObserver<EchoMessage>)asyncClient.echoStream(responseObserver);
+
+        messageBuilder = EchoMessage.newBuilder();
+        final int payloadLength = configuration.messageLength() - MIN_MESSAGE_LENGTH - 4 /* array length field */;
+        if (payloadLength <= 0)
+        {
+            payload = ByteString.EMPTY;
+        }
+        else
+        {
+            final byte[] bytes = new byte[payloadLength];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            payload = copyFrom(bytes);
+        }
+    }
+
+    public void destroy() throws Exception
+    {
+        requestObserver.onCompleted();
+
+        serverChannel.shutdown().awaitTermination(1, MINUTES);
+    }
+
+    public int send(final int numberOfMessages, final int length, final long timestamp, final long checksum)
+    {
+        final ClientCallStreamObserver<EchoMessage> requestObserver = this.requestObserver;
+        final EchoMessage.Builder messageBuilder = this.messageBuilder;
+        final ByteString payload = this.payload;
+        int count = 0;
+
+        for (int i = 0; i < numberOfMessages && requestObserver.isReady(); i++)
+        {
+            final EchoMessage request = messageBuilder
+                .setTimestamp(timestamp)
+                .setPayload(payload)
+                .setChecksum(checksum)
+                .build();
+
+            requestObserver.onNext(request);
+            count++;
+        }
+
+        return count;
+    }
+
+    public void receive()
+    {
+    }
+}

--- a/benchmarks-grpc/src/main/proto/grpc_benchmarks.proto
+++ b/benchmarks-grpc/src/main/proto/grpc_benchmarks.proto
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "uk.co.real_logic.benchmarks.grpc.remote";
+option java_outer_classname = "EchoBenchmarksProto";
+option objc_class_prefix = "GBP";
+
+package benchmarks;
+
+// Interface exported by the server.
+service EchoBenchmarks {
+  // A simple RPC.
+  rpc echo(EchoMessage) returns (EchoMessage) {}
+
+  // A Bidirectional streaming RPC.
+  rpc echoStream(stream EchoMessage) returns (stream EchoMessage) {}
+}
+
+message EchoMessage {
+  uint64 timestamp = 1;
+  bytes payload = 2;
+  uint64 checksum = 3;
+}

--- a/benchmarks-grpc/src/test/java/uk/co/real_logic/benchmarks/grpc/remote/AbstractGrpcTest.java
+++ b/benchmarks-grpc/src/test/java/uk/co/real_logic/benchmarks/grpc/remote/AbstractGrpcTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import org.agrona.collections.LongArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import uk.co.real_logic.benchmarks.remote.Configuration;
+import uk.co.real_logic.benchmarks.remote.MessageRecorder;
+import uk.co.real_logic.benchmarks.remote.MessageTransceiver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.co.real_logic.benchmarks.grpc.remote.GrpcConfig.getServerAddress;
+import static uk.co.real_logic.benchmarks.remote.Configuration.MIN_MESSAGE_LENGTH;
+
+abstract class AbstractGrpcTest
+{
+    @Timeout(30)
+    @Test
+    void messageLength16bytes() throws Exception
+    {
+        test(10_000, MIN_MESSAGE_LENGTH, 10);
+    }
+
+    @Timeout(30)
+    @Test
+    void messageLength200bytes() throws Exception
+    {
+        test(1000, 200, 5);
+    }
+
+    @Timeout(30)
+    @Test
+    void messageLength1KB() throws Exception
+    {
+        test(100, 1024, 1);
+    }
+
+    protected abstract MessageTransceiver createMessageTransceiver(MessageRecorder messageRecorder);
+
+    private void test(
+        final int numberOfMessages,
+        final int messageLength,
+        final int burstSize) throws Exception
+    {
+        try (EchoServer server = new EchoServer(getServerAddress()))
+        {
+            server.start();
+
+            final LongArrayList sentTimestamps = new LongArrayList();
+            final LongArrayList receivedTimestamps = new LongArrayList();
+            final MessageTransceiver messageTransceiver = createMessageTransceiver(
+                (timestamp, checksum) ->
+                {
+                    assertEquals(3 * timestamp, checksum);
+                    receivedTimestamps.addLong(timestamp);
+                });
+
+            final Configuration configuration = new Configuration.Builder()
+                .numberOfMessages(numberOfMessages)
+                .messageLength(messageLength)
+                .messageTransceiverClass(messageTransceiver.getClass())
+                .build();
+
+            messageTransceiver.init(configuration);
+            try
+            {
+
+                int sent = 0;
+                long timestamp = 1_000;
+                while (sent < numberOfMessages || receivedTimestamps.size() < numberOfMessages)
+                {
+                    if (Thread.interrupted())
+                    {
+                        throw new IllegalStateException("run cancelled!");
+                    }
+
+                    if (sent < numberOfMessages)
+                    {
+                        int sentBatch = 0;
+                        do
+                        {
+                            sentBatch +=
+                                messageTransceiver.send(burstSize - sentBatch, messageLength, timestamp, 3 * timestamp);
+                            messageTransceiver.receive();
+                        }
+                        while (sentBatch < burstSize);
+
+                        for (int i = 0; i < burstSize; i++)
+                        {
+                            sentTimestamps.add(timestamp);
+                        }
+
+                        sent += burstSize;
+                        timestamp++;
+                    }
+
+                    if (receivedTimestamps.size() < numberOfMessages)
+                    {
+                        messageTransceiver.receive();
+                    }
+                }
+
+                assertEquals(sentTimestamps, receivedTimestamps);
+            }
+            finally
+            {
+                messageTransceiver.destroy();
+            }
+        }
+    }
+}

--- a/benchmarks-grpc/src/test/java/uk/co/real_logic/benchmarks/grpc/remote/BlockingMessageTrasceiverTest.java
+++ b/benchmarks-grpc/src/test/java/uk/co/real_logic/benchmarks/grpc/remote/BlockingMessageTrasceiverTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import uk.co.real_logic.benchmarks.remote.MessageRecorder;
+import uk.co.real_logic.benchmarks.remote.MessageTransceiver;
+
+class BlockingMessageTrasceiverTest extends uk.co.real_logic.benchmarks.grpc.remote.AbstractGrpcTest
+{
+    protected MessageTransceiver createMessageTransceiver(final MessageRecorder messageRecorder)
+    {
+        return new BlockingMessageTrasceiver(messageRecorder);
+    }
+}

--- a/benchmarks-grpc/src/test/java/uk/co/real_logic/benchmarks/grpc/remote/StreamingMessageTrasceiverTest.java
+++ b/benchmarks-grpc/src/test/java/uk/co/real_logic/benchmarks/grpc/remote/StreamingMessageTrasceiverTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.benchmarks.grpc.remote;
+
+import uk.co.real_logic.benchmarks.remote.MessageRecorder;
+import uk.co.real_logic.benchmarks.remote.MessageTransceiver;
+
+class StreamingMessageTrasceiverTest extends uk.co.real_logic.benchmarks.grpc.remote.AbstractGrpcTest
+{
+    protected MessageTransceiver createMessageTransceiver(final MessageRecorder messageRecorder)
+    {
+        return new StreamingMessageTrasceiver(messageRecorder);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,9 @@ plugins {
     id 'java-library'
     id 'idea'
     id 'checkstyle'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
     id 'com.github.ben-manes.versions' version '0.28.0'
+    id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
+    id 'com.google.protobuf' version '0.8.12' apply false
 }
 
 defaultTasks 'clean', 'build'
@@ -37,6 +38,8 @@ def disruptorVersion = '3.4.2'
 def junitVersion = '5.6.2'
 def mockitoVersion = '3.3.3'
 def checkstyleVersion = '8.28'
+def grpcVersion = '1.29.0'
+def protobufVersion = '3.11.4'
 
 allprojects {
     repositories {
@@ -48,6 +51,7 @@ allprojects {
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'checkstyle'
+    apply plugin: 'idea'
 
     dependencies {
         testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
@@ -101,11 +105,33 @@ project(':benchmarks-aeron') {
     }
 }
 
+project(':benchmarks-grpc') {
+    apply plugin: 'com.google.protobuf'
+
+    dependencies {
+        api project(':benchmarks-api')
+        implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+        implementation "io.grpc:grpc-stub:${grpcVersion}"
+        implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
+    }
+
+    protobuf {
+        protoc { artifact = "com.google.protobuf:protoc:${protobufVersion}" }
+        plugins {
+            grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
+        }
+        generateProtoTasks {
+            all()*.plugins { grpc {} }
+        }
+    }
+}
+
 project(':benchmarks-all') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     dependencies {
         implementation project(':benchmarks-aeron')
+        implementation project(':benchmarks-grpc')
     }
 
     shadowJar {

--- a/scripts/grpc/blocking-client
+++ b/scripts/grpc/blocking-client
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+##
+## Copyright 2015-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+GRPC_DIR="`pwd`"
+
+cd ..
+./run-java -Duk.co.real_logic.benchmarks.remote.messageTransceiver=uk.co.real_logic.benchmarks.grpc.remote.BlockingMessageTrasceiver \
+  uk.co.real_logic.benchmarks.remote.LoadTestRig \
+  ${GRPC_DIR}/benchmark.properties \
+  "$@"

--- a/scripts/grpc/server
+++ b/scripts/grpc/server
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+##
+## Copyright 2015-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+GRPC_DIR="`pwd`"
+
+cd ..
+./run-java uk.co.real_logic.benchmarks.grpc.remote.EchoServer \
+  ${GRPC_DIR}/benchmark.properties \
+  "$@"

--- a/scripts/grpc/streaming-client
+++ b/scripts/grpc/streaming-client
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+##
+## Copyright 2015-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+GRPC_DIR="`pwd`"
+
+cd ..
+./run-java -Duk.co.real_logic.benchmarks.remote.messageTransceiver=uk.co.real_logic.benchmarks.grpc.remote.StreamingMessageTrasceiver \
+  uk.co.real_logic.benchmarks.remote.LoadTestRig \
+  ${GRPC_DIR}/benchmark.properties \
+  "$@"

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ rootProject.name = 'benchmarks'
 include (
     'benchmarks-api',
     'benchmarks-aeron',
+    'benchmarks-grpc',
     'benchmarks-all')


### PR DESCRIPTION
This PR adds a gRPC implementation of the `remote` benchmarks. It follows the same approach as was used for Aeron benchmarks with regards to launch scripts, naming etc.