### PR TITLE
fix java 9+ build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ def grpcVersion = '1.31.1'
 def protobufVersion = '3.13.0'
 def kafkaVersion = '2.6.0'
 def slf4jVersion = '1.7.30'
+def annotationsApiVersion = '6.0.53'
 
 allprojects {
     repositories {
@@ -115,6 +116,7 @@ project(':benchmarks-grpc') {
         implementation "io.grpc:grpc-protobuf:${grpcVersion}"
         implementation "io.grpc:grpc-stub:${grpcVersion}"
         implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
+        compileOnly "org.apache.tomcat:annotations-api:${annotationsApiVersion}"
     }
 
     protobuf {


### PR DESCRIPTION
that's a known issue with grpc https://github.com/grpc/grpc-java/issues/3633
why is not javax.annotation-api see here https://github.com/grpc/grpc-java/issues/6833