### PR TITLE
Small Configuration Changes and Sample

### DIFF
--- a/benchmarks-aeron/src/main/java/uk/co/real_logic/benchmarks/aeron/remote/ClusterNode.java
+++ b/benchmarks-aeron/src/main/java/uk/co/real_logic/benchmarks/aeron/remote/ClusterNode.java
@@ -15,7 +15,6 @@
  */
 package uk.co.real_logic.benchmarks.aeron.remote;
 
-import io.aeron.CommonContext;
 import io.aeron.archive.Archive;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.ConsensusModule;
@@ -43,8 +42,9 @@ public final class ClusterNode
 
         final AeronArchive.Context aeronArchiveContext = new AeronArchive.Context()
             .lock(NoOpLock.INSTANCE)
-            .controlRequestChannel(CommonContext.IPC_CHANNEL)
-            .controlResponseChannel(CommonContext.IPC_CHANNEL)
+            .controlRequestChannel(archiveContext.localControlChannel())
+            .controlResponseStreamId(archiveContext.localControlStreamId())
+            .controlResponseChannel(archiveContext.localControlChannel())
             .aeronDirectoryName(archiveContext.aeronDirectoryName());
 
         final ConsensusModule.Context consensusModuleContext = new ConsensusModule.Context()

--- a/benchmarks-aeron/src/main/java/uk/co/real_logic/benchmarks/aeron/remote/ClusterNode.java
+++ b/benchmarks-aeron/src/main/java/uk/co/real_logic/benchmarks/aeron/remote/ClusterNode.java
@@ -34,7 +34,7 @@ public final class ClusterNode
 {
     public static void main(final String[] args)
     {
-        SystemUtil.loadPropertiesFiles(PropertyAction.PRESERVE, args);
+        SystemUtil.loadPropertiesFiles(PropertyAction.REPLACE, args);
 
         final Archive.Context archiveContext = new Archive.Context()
             .deleteArchiveOnStart(true)

--- a/benchmarks-api/src/main/java/uk/co/real_logic/benchmarks/remote/LoadTestRig.java
+++ b/benchmarks-api/src/main/java/uk/co/real_logic/benchmarks/remote/LoadTestRig.java
@@ -290,7 +290,7 @@ public final class LoadTestRig
     public static void main(final String[] args) throws Exception
     {
         Thread.currentThread().setName("load-test-rig");
-        SystemUtil.loadPropertiesFiles(PropertyAction.PRESERVE, args);
+        SystemUtil.loadPropertiesFiles(PropertyAction.REPLACE, args);
 
         final Configuration configuration = Configuration.fromSystemProperties();
 

--- a/scripts/aeron/README.md
+++ b/scripts/aeron/README.md
@@ -42,84 +42,51 @@ Three different test scenarios are covered:
    Similar to the echo benchmark but with the messages being sent to the cluster using
    `io.aeron.cluster.client.AeronCluster.tryClaim` and received from the cluster using
    `io.aeron.cluster.client.AeronCluster.pollEgress` API.
-   
+
    Start the scripts in the following order: `cluster-node` ... -> `cluster-client`.
 
+   Look in the `scripts/samples/cluster_localhost` for an example of using the cluster benchmark running on localhost.
+   A simple approach for setting up a cluster test is to separate the configuration that is common across the cluster and specific to individual nodes/client into separate files.
+   The common cluster configuration options that need to be set are:
    For each cluster node the following properties must be configured:
-   - `aeron.dir` - a dedicated directory for the `MediaDriver`.
-   - `aeron.archive.dir` - a dedicated directory for the `Archive`.
-   - `aeron.cluster.dir` - a dedicated directory for the `ConsensusModule`.
    - `aeron.cluster.members` - the static list of cluster nodes.
-   - `aeron.cluster.member.id` - unique ID of the cluster node, must be one of the IDs in the cluster members list.
-   - `aeron.archive.control.channel` - `Archive` control channel, must be IPC.
-   - `aeron.archive.control.stream.id` - `Archive` control channel stream ID, must be unique across cluster nodes on
-   - `aeron.archive.control.response.channel` - `Archive` control response channel, must be IPC.
-   - `aeron.archive.control.response.stream.id` - `Archive` control response channel stream ID, must be unique across 
-     cluster nodes on the same machine.
-   - `aeron.cluster.log.channel` - log channel for distributing cluster log. Usually configured as multicast or as
-     multi destination cast. Must match the third part of the corresponding cluster members entry.
+   - `aeron.cluster.replication.channel` - Endpoint used for replicating logs between various nodes during elections.
+     Can be the node's address (e.g. localhost when testing locally) with a port of 0 (dynamically assigned).
    - `aeron.cluster.ingress.channel` - an ingress channel to which messages to the cluster will be sent. Can be
      configured as multicast for efficiency. Must match the first part of the corresponding cluster members entry.
    - `aeron.cluster.ingress.endpoints` - a list of ingress endpoints which will be substituted into
      `aeron.cluster.ingress.channel` for endpoints. Should not be set if the `aeron.cluster.ingress.channel` is
      multicast. This is client-only property.
-     
-   Here is a sample config for a three node cluster benchmark:
-   ```bash
-    # node 0
-    aeron.dir=/dev/shm/node0-driver
-    aeron.cluster.dir=/tmp/node0-cluster
-    aeron.cluster.member.id=0
-    aeron.cluster.members=0,localhost:20000,localhost:20001,localhost:20002,localhost:20003,localhost:20004|\
-    1,localhost:21000,localhost:21001,localhost:21002,localhost:21003,localhost:21004|\
-    2,localhost:22000,localhost:22001,localhost:22002,localhost:22003,localhost:22004
-    aeron.cluster.log.channel=aeron:udp?control-mode=manual|control=localhost:20002
-    aeron.cluster.ingress.channel=aeron:udp
-    aeron.archive.dir=/tmp/node0-archive
-    aeron.archive.control.channel=aeron:ipc
-    aeron.archive.control.stream.id=100
-    aeron.archive.control.response.channel=aeron:ipc
-    aeron.archive.control.response.stream.id=200
-    aeron.archive.recording.events.enabled=false
-    
-    # node 1
-    aeron.dir=/dev/shm/node1-driver
-    aeron.cluster.dir=/tmp/node1-cluster
-    aeron.cluster.member.id=1
-    aeron.cluster.members=0,localhost:20000,localhost:20001,localhost:20002,localhost:20003,localhost:20004|\
-    1,localhost:21000,localhost:21001,localhost:21002,localhost:21003,localhost:21004|\
-    2,localhost:22000,localhost:22001,localhost:22002,localhost:22003,localhost:22004
-    aeron.cluster.log.channel=aeron:udp?control-mode=manual|control=localhost:21002
-    aeron.cluster.ingress.channel=aeron:udp
-    aeron.archive.dir=/tmp/node1-archive
-    aeron.archive.control.channel=aeron:ipc
-    aeron.archive.control.stream.id=101
-    aeron.archive.control.response.channel=aeron:ipc
-    aeron.archive.control.response.stream.id=201
-    aeron.archive.recording.events.enabled=false
-    
-    # node2
-    aeron.dir=/dev/shm/node2-driver
-    aeron.cluster.dir=/tmp/node2-cluster
-    aeron.cluster.member.id=2
-    aeron.cluster.members=0,localhost:20000,localhost:20001,localhost:20002,localhost:20003,localhost:20004|\
-    1,localhost:21000,localhost:21001,localhost:21002,localhost:21003,localhost:21004|\
-    2,localhost:22000,localhost:22001,localhost:22002,localhost:22003,localhost:22004
-    aeron.cluster.log.channel=aeron:udp?control-mode=manual|control=localhost:22002
-    aeron.cluster.ingress.channel=aeron:udp
-    aeron.archive.dir=/tmp/node2-archive
-    aeron.archive.control.channel=aeron:ipc
-    aeron.archive.control.stream.id=102
-    aeron.archive.control.response.channel=aeron:ipc
-    aeron.archive.control.response.stream.id=202
-    aeron.archive.recording.events.enabled=false
-    
-    # client
-    aeron.cluster.ingress.channel=aeron:udp
-    aeron.cluster.ingress.endpoints=0=localhost:20000,1=localhost:21000,2=localhost:22000
-    aeron.cluster.egress.channel=aeron:udp?endpoint=localhost:0
-   ```
-    
+   
+   For each Cluster node the follow options need to be set.
+   When running locally these need to be different to avoid having nodes collide into each other.  
+   - `aeron.dir` - a dedicated directory for the `MediaDriver`.
+   - `aeron.archive.dir` - a dedicated directory for the `Archive`.
+   - `aeron.cluster.dir` - a dedicated directory for the `ConsensusModule` and `ClusteredService`.
+   - `aeron.cluster.member.id` - unique ID of the cluster node, must be one of the IDs in the cluster members list.
+
+   For the client the following options need to be set:
+   - `aeron.dir` - a dedicated directory for the `MediaDriver`.
+   - `aeron.cluster.egress.channel` - the channel for the cluster to send message back to the client.
+5. Before running the nodes and client, each will need a media driver running.
+   The commands will look similar to the following.
+   Each command will block, so will need to be run in separate terminals.
+   The default media driver and memory settings are configured for performance, so when running locally you may need to turn down the amount of memory committed up front to prevent OOMEs.
+
+```bash
+> JVM_OPTS='-Xms16M' ./scripts/aeron/media-driver ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/node0.properties
+> JVM_OPTS='-Xms16M' ./scripts/aeron/cluster-node ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/node0.properties
+
+> JVM_OPTS='-Xms16M' ./scripts/aeron/media-driver ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/node1.properties
+> JVM_OPTS='-Xms16M' ./scripts/aeron/cluster-node ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/node1.properties
+
+> JVM_OPTS='-Xms16M' ./scripts/aeron/media-driver ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/node2.properties
+> JVM_OPTS='-Xms16M' ./scripts/aeron/cluster-node ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/node2.properties
+
+> JVM_OPTS='-Xms16M' ./scripts/aeron/media-driver ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/client.properties
+> JVM_OPTS='-Xms16M' ./scripts/aeron/cluster-client ./scripts/samples/cluster_localhost/cluster.properties ./scripts/samples/cluster_localhost/client.properties
+```
+
 
 Helper scripts
 --------------

--- a/scripts/samples/cluster_localhost/client.properties
+++ b/scripts/samples/cluster_localhost/client.properties
@@ -1,0 +1,4 @@
+aeron.dir=/dev/shm/client-driver
+aeron.cluster.egress.channel=aeron:udp?endpoint=localhost:0
+uk.co.real_logic.benchmarks.remote.message.rate=100
+uk.co.real_logic.benchmarks.remote.output.file=bench_out.txt

--- a/scripts/samples/cluster_localhost/cluster.properties
+++ b/scripts/samples/cluster_localhost/cluster.properties
@@ -1,0 +1,17 @@
+aeron.cluster.members=0,localhost:20000,localhost:20001,localhost:20002,localhost:20003,localhost:20004|\
+ 1,localhost:21000,localhost:21001,localhost:21002,localhost:21003,localhost:21004|\
+ 2,localhost:22000,localhost:22001,localhost:22002,localhost:22003,localhost:22004
+aeron.cluster.replication.channel=aeron:udp?endpoint=localhost:0
+aeron.cluster.ingress.channel=aeron:udp
+aeron.cluster.ingress.endpoints=0=localhost:20000,1=localhost:21000,2=localhost:22000
+aeron.archive.recording.events.enabled=false
+
+# Reduce window sizes when running locally to prevent excessive memory usage.
+# Remove these options when running in a production-like environment.
+aeron.term.buffer.sparse.file=true
+aeron.pre.touch.mapped.memory=false
+aeron.socket.so_sndbuf=128k
+aeron.socket.so_rcvbuf=128k
+aeron.rcv.initial.window.length=128k
+aeron.term.buffer.length=128k
+aeron.ipc.term.buffer.length=128k

--- a/scripts/samples/cluster_localhost/node0.properties
+++ b/scripts/samples/cluster_localhost/node0.properties
@@ -1,0 +1,4 @@
+aeron.dir=/dev/shm/node0-driver
+aeron.cluster.dir=cluster/node0/cluster
+aeron.cluster.member.id=0
+aeron.archive.dir=cluster/node0/archive

--- a/scripts/samples/cluster_localhost/node1.properties
+++ b/scripts/samples/cluster_localhost/node1.properties
@@ -1,0 +1,4 @@
+aeron.dir=/dev/shm/node1-driver
+aeron.cluster.dir=cluster/node1/cluster
+aeron.cluster.member.id=1
+aeron.archive.dir=cluster/node1/archive

--- a/scripts/samples/cluster_localhost/node2.properties
+++ b/scripts/samples/cluster_localhost/node2.properties
@@ -1,0 +1,4 @@
+aeron.dir=/dev/shm/node2-driver
+aeron.cluster.dir=cluster/node2/cluster
+aeron.cluster.member.id=2
+aeron.archive.dir=cluster/node2/archive


### PR DESCRIPTION
- Changes LoadTestRig and ClusterNode to use `PropertyAction.REPLACE` to allow configuration options to be override where appropriate.
- Tweak the ClusterNode to derive `AeronArchive` settings from the `Archive` and reduce the amount of configuration options required.
- Add sample localhost configuration properties
- Change README.md to reference new sample and change in the ClusterNode.