### PR TITLE
Result processing improvements

### DIFF
--- a/benchmarks-api/src/main/java/uk/co/real_logic/benchmarks/remote/Configuration.java
+++ b/benchmarks-api/src/main/java/uk/co/real_logic/benchmarks/remote/Configuration.java
@@ -384,10 +384,10 @@ public final class Configuration
         }
 
         return prefix +
-            "_rate-" + messageRate +
-            "_batch-" + batchSize +
-            "_length-" + messageLength +
-            "_sha-" + computeSha256(systemProperties);
+            "^rate=" + messageRate +
+            "^batch=" + batchSize +
+            "^length=" + messageLength +
+            "^sha=" + computeSha256(systemProperties);
     }
 
     /**

--- a/benchmarks-api/src/test/java/uk/co/real_logic/benchmarks/remote/ConfigurationTest.java
+++ b/benchmarks-api/src/test/java/uk/co/real_logic/benchmarks/remote/ConfigurationTest.java
@@ -324,8 +324,8 @@ class ConfigurationTest
             .build();
 
         assertEquals(
-            "the-prefix_rate-12_batch-3_length-75" +
-            "_sha-a2bea3034417edbbe21e66dd9b68d43fe53e287e04a1f6b119741ab9e0729f60",
+            "the-prefix^rate=12^batch=3^length=75" +
+            "^sha=a2bea3034417edbbe21e66dd9b68d43fe53e287e04a1f6b119741ab9e0729f60",
             configuration.outputFileNamePrefix());
     }
 
@@ -348,8 +348,8 @@ class ConfigurationTest
         assertSame(InMemoryMessageTransceiver.class, configuration.messageTransceiverClass());
         assertSame(NoOpIdleStrategy.INSTANCE, configuration.idleStrategy());
         assertEquals(Paths.get("results").toAbsolutePath(), configuration.outputDirectory());
-        assertEquals("defaults_rate-123_batch-" + DEFAULT_BATCH_SIZE + "_length-" + MIN_MESSAGE_LENGTH +
-            "_sha-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        assertEquals("defaults^rate=123^batch=" + DEFAULT_BATCH_SIZE + "^length=" + MIN_MESSAGE_LENGTH +
+            "^sha=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             configuration.outputFileNamePrefix());
     }
 
@@ -408,8 +408,8 @@ class ConfigurationTest
             "\n    messageTransceiverClass=uk.co.real_logic.benchmarks.remote.InMemoryMessageTransceiver" +
             "\n    idleStrategy=NoOpIdleStrategy{alias=noop}" +
             "\n    outputDirectory=" + Paths.get("results").toAbsolutePath() +
-            "\n    outputFileNamePrefix=my-file_rate-777_batch-2_length-64" +
-            "_sha-73ccec448ba12264acb12e7f9f36fddc73e8c62e43549b786a901c88891610c9" +
+            "\n    outputFileNamePrefix=my-file^rate=777^batch=2^length=64" +
+            "^sha=73ccec448ba12264acb12e7f9f36fddc73e8c62e43549b786a901c88891610c9" +
             "\n}",
             configuration.toString());
     }

--- a/benchmarks-kafka/src/main/java/uk/co/real_logic/benchmarks/kafka/remote/KafkaMessageTransceiver.java
+++ b/benchmarks-kafka/src/main/java/uk/co/real_logic/benchmarks/kafka/remote/KafkaMessageTransceiver.java
@@ -116,7 +116,7 @@ public class KafkaMessageTransceiver extends MessageTransceiver
     private void createTopic(final Configuration configuration)
     {
         final String outputFileNamePrefix = configuration.outputFileNamePrefix();
-        topic = "benchmark-" + outputFileNamePrefix.substring(outputFileNamePrefix.lastIndexOf('_') + 1);
+        topic = "benchmark-" + outputFileNamePrefix.substring(outputFileNamePrefix.lastIndexOf("sha=") + 4);
 
         final Properties config = new Properties();
         config.putAll(getCommonProperties());

--- a/scripts/aeron/remote-cluster-benchmarks
+++ b/scripts/aeron/remote-cluster-benchmarks
@@ -87,6 +87,7 @@ so_rcvbuf="${AERON_SOCKET_SO_RCVBUF:-2m}"
 rcv_initial_window="${AERON_RCV_INITIAL_WINDOW_LENGTH:-2m}"
 max_messages_per_send="${AERON_NETWORK_PUBLICATION_MAX_MESSAGES_PER_SEND:-2}"
 
+context=""
 enable_java_driver=1
 no_java_driver=0
 enable_c_driver=1
@@ -97,12 +98,15 @@ enable_dpdk=1
 enable_ats=1
 file_sync_levels=(0)
 mtu_list=(1408 8896)
-results_file="aeron-cluster-results"
 onload="onload --profile=latency --force-profiles "
 
 while [[ $# -gt 0 ]]
 do
   case "${1}" in
+  --context)
+    context="${2}"
+    shift
+    ;;
   --disable-c-driver)
     enable_c_driver=0
     shift
@@ -147,11 +151,6 @@ do
     shift
     shift
     ;;
-  --results-file)
-    results_file="${2}"
-    shift
-    shift
-    ;;
   --mtu)
     IFS=','
     read -ra mtu_list <<< "${2}"
@@ -160,7 +159,7 @@ do
     shift
     ;;
   -h | --help)
-    echo "${0} [--no-c-driver] [--no-java-driver] [--no-onload] [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--no-ats] [--file-sync-level \"\${file-sync-level-csv}\"] [--mtu \"\$mtu-csv\"]"
+    echo "${0} [--context] [--no-c-driver] [--no-java-driver] [--no-onload] [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--no-ats] [--file-sync-level \"\${file-sync-level-csv}\"] [--mtu \"\$mtu-csv\"]"
     exit
     ;;
   *)
@@ -427,7 +426,7 @@ do
   do
     for mtu in "${mtu_list[@]}"
     do
-      test="cluster_${scenario}_params_fsync-${fsync}_mtu-${mtu}_rcvwnd-${rcv_initial_window}"
+      test="cluster_${scenario}_${context}^fsync=${fsync}^mtu=${mtu}^rcvwnd=${rcv_initial_window}"
       echo -e "\n Testing scenario: '${test}'\n"
 
       driver="${commands[index]//driver_mtu_var/${mtu}}"
@@ -528,4 +527,4 @@ done
 
 collect_environment_info "${CLIENT_BENCHMARKS_PATH}/scripts" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${CLIENT_JAVA_HOME}"
 
-download_results "${results_file}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."
+download_results "cluster" "${context}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."

--- a/scripts/aeron/remote-echo-benchmarks
+++ b/scripts/aeron/remote-echo-benchmarks
@@ -63,6 +63,7 @@ so_rcvbuf="${AERON_SOCKET_SO_RCVBUF:-2m}"
 rcv_initial_window="${AERON_RCV_INITIAL_WINDOW_LENGTH:-2m}"
 max_messages_per_send="${AERON_NETWORK_PUBLICATION_MAX_MESSAGES_PER_SEND:-2}"
 
+context=""
 enable_java_driver=1
 no_java_driver=0
 enable_c_driver=1
@@ -72,12 +73,15 @@ enable_ef_vi=1
 enable_dpdk=1
 enable_ats=1
 mtu_list=(1408 8896)
-results_file="aeron-echo-results"
 onload="onload --profile=latency --force-profiles "
 
 while [[ $# -gt 0 ]]
 do
   case "${1}" in
+  --context)
+    context="${2}"
+    shift
+    ;;
   --disable-c-driver)
     enable_c_driver=0
     shift
@@ -115,11 +119,6 @@ do
     enable_ats=0
     shift
     ;;
-  --results-file)
-    results_file="${2}"
-    shift
-    shift
-    ;;
   --mtu)
     IFS=',';
     read -ra mtu_list <<< "${2}"
@@ -128,7 +127,7 @@ do
     shift
     ;;
   -h|--help)
-    echo "${0} [--no-c-driver] [--no-java-driver] [--no-onload] [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--no-ats] [--mtu \"\$mtu-csv\"]"
+    echo "${0} [--context] [--no-c-driver] [--no-java-driver] [--no-onload] [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--no-ats] [--mtu \"\$mtu-csv\"]"
     exit
     ;;
   *)
@@ -274,7 +273,7 @@ do
   scenario="${scenarios[index]}"
   for mtu in "${mtu_list[@]}"
   do
-    test="echo_${scenario}_params_mtu-${mtu}_rcvwnd-${rcv_initial_window}"
+    test="echo_${scenario}_${context}^mtu=${mtu}^rcvwnd=${rcv_initial_window}"
     echo -e "\n Testing scenario: '${test}'\n"
 
     driver="${commands[index]//driver_mtu_var/${mtu}}"
@@ -356,4 +355,4 @@ done
 
 collect_environment_info "${CLIENT_BENCHMARKS_PATH}/scripts" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${CLIENT_JAVA_HOME}"
 
-download_results "${results_file}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."
+download_results "echo" "${context}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."

--- a/scripts/aeron/remote-live-recording-benchmarks
+++ b/scripts/aeron/remote-live-recording-benchmarks
@@ -66,6 +66,7 @@ so_rcvbuf="${AERON_SOCKET_SO_RCVBUF:-2m}"
 rcv_initial_window="${AERON_RCV_INITIAL_WINDOW_LENGTH:-2m}"
 max_messages_per_send="${AERON_NETWORK_PUBLICATION_MAX_MESSAGES_PER_SEND:-2}"
 
+context=""
 enable_c_driver=1
 no_c_driver=0
 enable_java_driver=1
@@ -73,12 +74,15 @@ enable_ef_vi=1
 enable_dpdk=1
 file_sync_levels=(0 2)
 mtu_list=(1408 8896)
-results_file="aeron-live-recording-results"
 onload="onload --profile=latency --force-profiles "
 
 while [[ $# -gt 0 ]]
 do
   case "${1}" in
+  --context)
+    context="${2}"
+    shift
+    ;;
   --disable-c-driver)
     enable_c_driver=0
     shift
@@ -111,11 +115,6 @@ do
     shift
     shift
     ;;
-  --results-file)
-    results_file="${2}"
-    shift
-    shift
-    ;;
   --mtu)
     IFS=','
     read -ra mtu_list <<< "${2}"
@@ -124,7 +123,7 @@ do
     shift
     ;;
   -h|--help)
-    echo "${0} [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--disable-c-driver] [--no-c-driver] [--disable-java-driver] [--file-sync-level \"\${file-sync-level-csv}\"] [--mtu \"\$mtu-csv\"]"
+    echo "${0} [--context] [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--disable-c-driver] [--no-c-driver] [--disable-java-driver] [--file-sync-level \"\${file-sync-level-csv}\"] [--mtu \"\$mtu-csv\"]"
     exit
     ;;
   *)
@@ -210,7 +209,7 @@ do
   do
     for mtu in "${mtu_list[@]}"
     do
-      test="live-recording_${scenario}_params_fsync-${fsync}_mtu-${mtu}_rcvwnd-${rcv_initial_window}"
+      test="live-recording_${scenario}_${context}^fsync=${fsync}^mtu=${mtu}^rcvwnd=${rcv_initial_window}"
       echo -e "\n Testing scenario: '${test}'\n"
 
       driver="${commands[index]//driver_mtu_var/${mtu}}"
@@ -292,4 +291,4 @@ done
 
 collect_environment_info "${CLIENT_BENCHMARKS_PATH}/scripts" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${CLIENT_JAVA_HOME}"
 
-download_results "${results_file}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."
+download_results "live-recording" "${context}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."

--- a/scripts/aeron/remote-live-replay-benchmarks
+++ b/scripts/aeron/remote-live-replay-benchmarks
@@ -65,6 +65,7 @@ so_rcvbuf="${AERON_SOCKET_SO_RCVBUF:-2m}"
 rcv_initial_window="${AERON_RCV_INITIAL_WINDOW_LENGTH:-2m}"
 max_messages_per_send="${AERON_NETWORK_PUBLICATION_MAX_MESSAGES_PER_SEND:-2}"
 
+context=""
 enable_c_driver=1
 no_c_driver=0
 enable_java_driver=1
@@ -72,12 +73,15 @@ enable_ef_vi=1
 enable_dpdk=1
 file_sync_levels=(0 2)
 mtu_list=(1408 8896)
-results_file="aeron-live-replay-results"
 onload="onload --profile=latency --force-profiles "
 
 while [[ $# -gt 0 ]]
 do
   case "${1}" in
+  --context)
+    context="${2}"
+    shift
+    ;;
   --disable-c-driver)
     enable_c_driver=0
     shift
@@ -110,11 +114,6 @@ do
     shift
     shift
     ;;
-  --results-file)
-    results_file="${2}"
-    shift
-    shift
-    ;;
   --mtu)
     IFS=','
     read -ra mtu_list <<< "${2}"
@@ -123,7 +122,7 @@ do
     shift
     ;;
   -h|--help)
-    echo "${0} [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--disable-c-driver] [--no-c-driver] [--disable-java-driver] [--file-sync-level \"\${file-sync-level-csv}\"] [--mtu \"\$mtu-csv\"]"
+    echo "${0} [--context] [--onload \"\$onload_command\"] [--no-ef_vi] [--no-dpdk] [--disable-c-driver] [--no-c-driver] [--disable-java-driver] [--file-sync-level \"\${file-sync-level-csv}\"] [--mtu \"\$mtu-csv\"]"
     exit
     ;;
   *)
@@ -209,7 +208,7 @@ do
   do
     for mtu in "${mtu_list[@]}"
     do
-      test="live-replay_${scenario}_params_fsync-${fsync}_mtu-${mtu}_rcvwnd-${rcv_initial_window}"
+      test="live-replay_${scenario}_${context}^fsync=${fsync}^mtu=${mtu}^rcvwnd=${rcv_initial_window}"
       echo -e "\n Testing scenario: '${test}'\n"
 
       driver="${commands[index]//driver_mtu_var/${mtu}}"
@@ -294,4 +293,4 @@ done
 
 collect_environment_info "${CLIENT_BENCHMARKS_PATH}/scripts" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${CLIENT_JAVA_HOME}"
 
-download_results "${results_file}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."
+download_results "live-replay" "${context}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."

--- a/scripts/grpc/remote-grpc-benchmarks
+++ b/scripts/grpc/remote-grpc-benchmarks
@@ -60,14 +60,17 @@ then
   exit 1
 fi
 
-
+context=""
 tls_options=("false" "true")
-results_file="grpc-results"
 onload="onload --profile=latency --force-profiles"
 
 while [[ $# -gt 0 ]]
 do
   case "${1}" in
+  --context)
+    context="${2}"
+    shift
+    ;;
   --no-tls)
     tls_options=("false")
     shift
@@ -81,13 +84,8 @@ do
     shift
     shift
     ;;
-  --results-file)
-    results_file="${2}"
-    shift
-    shift
-    ;;
   -h|--help)
-    echo "${0} [--no-tls] [--no-onload] [--onload \"\$onload_command\"]"
+    echo "${0} [--context] [--no-tls] [--no-onload] [--onload \"\$onload_command\"]"
     exit
     ;;
   *)
@@ -111,7 +109,7 @@ do
       scenario="${scenario}-onload"
   fi
 
-  test="grpc_${scenario}"
+  test="grpc_${scenario}_${context}"
 
   echo -e "\n Testing scenario: '${test}'\n"
 
@@ -152,4 +150,4 @@ done
 
 collect_environment_info "${CLIENT_BENCHMARKS_PATH}/scripts" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${CLIENT_JAVA_HOME}"
 
-download_results "${results_file}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."
+download_results "grpc" "${context}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."

--- a/scripts/kafka/remote-kafka-benchmarks
+++ b/scripts/kafka/remote-kafka-benchmarks
@@ -48,13 +48,17 @@ then
   exit 1
 fi
 
+context=""
 security_protocols=("PLAINTEXT" "SSL")
 onload="onload --profile=latency --force-profiles"
-results_file="kafka-results"
 
 while [[ $# -gt 0 ]]
 do
   case "${1}" in
+  --context)
+    context="${2}"
+    shift
+    ;;
   --no-ssl)
     security_protocols=("PLAINTEXT")
     shift
@@ -68,13 +72,8 @@ do
     shift
     shift
     ;;
-  --results-file)
-    results_file="${2}"
-    shift
-    shift
-    ;;
   -h|--help)
-    echo "${0} [--no-ssl] [--no-onload] [--onload \"\$onload_command\"]"
+    echo "${0} [--context] [--no-ssl] [--no-onload] [--onload \"\$onload_command\"]"
     exit
     ;;
   *)
@@ -114,8 +113,8 @@ do
       port=${ssl_port}
     fi
 
-    test=$(printf ",%s" "${foo[@]}")
-    test="kafka_${test:1}"
+    test=$(printf "-%s" "${scenario[@]}")
+    test="kafka_${test:1}_${context}"
 
     echo -e "\n Testing scenario: '${test}'\n"
 
@@ -156,4 +155,4 @@ done
 
 collect_environment_info "${CLIENT_BENCHMARKS_PATH}/scripts" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${CLIENT_JAVA_HOME}"
 
-download_results "${results_file}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."
+download_results "kafka" "${context}" "${CLIENT_BENCHMARKS_PATH}/scripts/results" "${DIR}/.."

--- a/scripts/remote-benchmarks-runner
+++ b/scripts/remote-benchmarks-runner
@@ -133,9 +133,9 @@ function collect_environment_info()
 
 function download_results()
 {
-  local archive="/home/${SSH_USER}/${1}.tar.gz"
-  local results_dir="${2}"
-  local dest_dir="${3}"
+  local archive="/home/${SSH_USER}/${1}_$(date '+%Y-%m-%d-%H-%M-%S')_${2}.tar.gz"
+  local results_dir="${3}"
+  local dest_dir="${4}"
 
   execute_remote_command "${SSH_CLIENT_NODE}" "rm -f \"${archive}\"; cd \"${results_dir}\" && tar -czf \"${archive}\" . && exit"
   scp -i "${SSH_KEY_FILE}" \

--- a/scripts/results-plotter.py
+++ b/scripts/results-plotter.py
@@ -106,13 +106,22 @@ def filter_files(files, filters, exclude=False):
 
     accepted_files = set()
     for f in files:
+        should_append = True
         for filter_field in filters:
             field_value = f.fields[filter_field]
             if field_value in filters[filter_field]:
                 if not exclude:
-                    accepted_files.add(f)
-            elif exclude:
-                accepted_files.add(f)
+                    should_append = should_append and True
+                else:
+                    should_append = should_append and False
+            else:
+                if not exclude:
+                    should_append = should_append and False
+                else:
+                    should_append = should_append and True
+
+        if filters and should_append:
+            accepted_files.add(f)
 
     if not filters:
         accepted_files = files


### PR DESCRIPTION
- introduce `--context` switch for benchmark runner scripts
- generate the archive file name instead of taking it as input
- use `key1=value1^key2=value2` as format for the parameters
- remove distinction between "context" and "normal" parameters
- filters of the results plotter are now AND filters instead of OR filters
- support multiple input directories for the results plotter