### PR TITLE
Use a pseudoterminal when running a process with exec

### DIFF
--- a/scripts/remote-benchmarks-runner
+++ b/scripts/remote-benchmarks-runner
@@ -110,7 +110,12 @@ function run_benchmarks()
         client_jvm_opts="${client_jvm_opts%?}\""
 
         echo -e "\nStarting server..."
-        execute_remote_command "${SSH_SERVER_NODE}" "(${server_start_command} &) > /tmp/benchmarks-server.log 2>&1 && exit"
+        if [[ $server_start_command =~ ^exec\ sudo ]]; then
+          # run forked process in a pseudoterminal
+          execute_remote_command_pty "${SSH_SERVER_NODE}" "(${server_start_command} &) > /tmp/benchmarks-server.log 2>&1 && exit"
+        else
+          execute_remote_command "${SSH_SERVER_NODE}" "(${server_start_command} &) > /tmp/benchmarks-server.log 2>&1 && exit"
+        fi
 
         echo -e "\nStarting client..."
         execute_remote_command "${SSH_CLIENT_NODE}" "${client_jvm_opts} && ${client_command} && exit"
@@ -183,6 +188,18 @@ function execute_remote_command()
   local server=$1
   local command=$2
   ssh -i "${SSH_KEY_FILE}" \
+   -o ConnectionAttempts="${sshConnectionAttempts}" \
+   -o ConnectTimeout="${sshConnectTimeout}" \
+   -o ServerAliveInterval="${sshServerAliveInterval}" \
+   "${SSH_USER}"@"${server}" \
+   "${command}"
+}
+
+function execute_remote_command_pty()
+{
+  local server=$1
+  local command=$2
+  ssh -t -i "${SSH_KEY_FILE}" \
    -o ConnectionAttempts="${sshConnectionAttempts}" \
    -o ConnectTimeout="${sshConnectTimeout}" \
    -o ServerAliveInterval="${sshServerAliveInterval}" \


### PR DESCRIPTION
When running the benchmarks scripts as a subprocess of a python script, the `exec sudo ...` commands fail (because `sudo` can't find a terminal)