### PR TITLE
feat(CAF-552): Improvements to K8s reports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 .github
 .gradle
-Dockerfile
 .git*
-.dockerignore
-**/k8s*.yml
+scripts/k8s/*.yml

--- a/scripts/collect-environment-info
+++ b/scripts/collect-environment-info
@@ -41,7 +41,12 @@ KERNEL=$(uname -r)
 ARCHITECTURE=$(arch)
 CPU_NAME=$(awk -F':' '/^model name/ {print $2}' /proc/cpuinfo | uniq | sed -e 's/^[ \t]*//')
 CMDLINE=$(cat /proc/cmdline)
-TUNED_PROFILE=$(tuned-adm profile | grep "Current active profile:" | cut -d':' -f2 | sed 's/^ *//g')
+if which tuned-adm > /dev/null
+then
+  TUNED_PROFILE=$(tuned-adm profile | grep "Current active profile:" | cut -d':' -f2 | sed 's/^ *//g')
+else
+  TUNED_PROFILE="container"
+fi
 if [[ -z $JDK_HOME ]]; then
   JAVA_VERSION="Java not available"
 else

--- a/scripts/k8s/k8s-benchmark-entrypoint.sh
+++ b/scripts/k8s/k8s-benchmark-entrypoint.sh
@@ -6,6 +6,13 @@ echo '***********************************'
 echo "*** Running $* on ${HOSTNAME} ***"
 echo '***********************************'
 
+# Create the results dir
+mkdir -p "${TEST_OUTPUT_PATH:? Please set TEST_OUTPUT_PATH}"
+cd "${BENCHMARKS_PATH:? Please set BENCHMARKS_PATH}/scripts"
+
+# Collecting environment info
+./collect-environment-info "${TEST_OUTPUT_PATH}"
+
 # Verify we can get DNS records for the pods
 until host "${NODE0_ADDRESS:? Please set NODE0_ADDRESS}"
 do
@@ -18,10 +25,6 @@ do
   sleep 5
 done
 
-# Create the results dir
-mkdir -p "${TEST_OUTPUT_PATH:? Please set TEST_OUTPUT_PATH}"
-
-cd "${BENCHMARKS_PATH:? Please set BENCHMARKS_PATH}/scripts"
 echo '*******************************'
 echo "JVM_OPTS:"
 echo "${JVM_OPTS:? Please set JVM_OPTS}" | sed "s/ /\n/g"
@@ -35,6 +38,8 @@ if [ -z "$(ls -A ${TEST_OUTPUT_PATH})" ]; then
 else
    parent_dir="$(dirname "${TEST_OUTPUT_PATH}")"
    results_dir="$(basename "${TEST_OUTPUT_PATH}")"
+   echo "Generating summary"
+   "${BENCHMARKS_PATH}/scripts/aggregate-results" "${TEST_OUTPUT_PATH}"
    echo "Creating results tarball: ${parent_dir}/results.tar.gz"
    tar -C "${parent_dir}" -czf "${parent_dir}/results.tar.gz" "${results_dir}"
 fi

--- a/scripts/k8s/k8s-benchmark.yml
+++ b/scripts/k8s/k8s-benchmark.yml
@@ -182,21 +182,6 @@ spec:
   # dnsPolicy: ClusterFirstWithHostNet
   containers:
     - name: benchmark
-      image: 453667550218.dkr.ecr.eu-west-1.amazonaws.com/aeron-benchmarks
-      # make this a variable
-      args:
-        - "./benchmark-runner"
-        - "--output-file"
-        - "aeron-echo-test"
-        - "--message-rate"
-        - "100K"
-        - "--burst-size"
-        - "1"
-        - "--message-length"
-        - "288"
-        - "--iterations"
-        - "30"
-        - "aeron/echo-client"
       envFrom:
         - configMapRef:
             name: aeron-benchmark-envs

--- a/scripts/k8s/k8s-test-customisation.yml
+++ b/scripts/k8s/k8s-test-customisation.yml
@@ -1,0 +1,23 @@
+---
+# This file is dynamically updated by the benchmarking script
+# Any modifications will be lost
+apiVersion: v1
+kind: Pod
+metadata:
+  name: all
+spec:
+  containers:
+    - name: benchmark
+      args:
+        - "./benchmark-runner"
+        - "--output-file"
+        - "aeron-echo_c-dpdk-k8s"
+        - "--message-rate"
+        - "100K"
+        - "--burst-size"
+        - "1"
+        - "--message-length"
+        - "288"
+        - "--iterations"
+        - "30"
+        - "aeron/echo-client"

--- a/scripts/k8s/kustomization.yml
+++ b/scripts/k8s/kustomization.yml
@@ -4,3 +4,8 @@ patches:
   - path: settings.yml
     target:
       kind: Pod
+  # This file is written dynamically by the load-testing script to inject the test config
+  - path: k8s-test-customisation.yml
+    target:
+      kind: Pod
+      name: aeron-benchmark-1

--- a/scripts/k8s/settings.yml
+++ b/scripts/k8s/settings.yml
@@ -15,10 +15,10 @@ spec:
 
   containers:
     - name: benchmark
-      image: 453667550218.dkr.ecr.eu-west-1.amazonaws.com/aeron-benchmarks
+      image: <add_your_benchmark_repo_here>
 
     - name: aeronmd-dpdk
-      image: 453667550218.dkr.ecr.eu-west-1.amazonaws.com/aeronmd-dpdk
+      image: <add_your_dpdk_repo_here>
       resources:
         limits:
           # Give us a DPDK NIC through https://github.com/AdaptiveConsulting/k8s-dpdk-mgr


### PR DESCRIPTION
Adds the following on K8s:
* Gradle caching for the Docker build
* Making `tuned-adm` optional during `collect-environment-info`. Containers won't have this.
* Moving more work into the container, so people don't have to have a local gradle build.
* Prep-work for dynamic test configuration
* Adding `collect-environment-info` output into test results
* Change of execution container to Zulu-17