### PR TITLE
Include the date/time when a run of a benchmark starts.

### DIFF
--- a/scripts/aeron/remote-archive-replay-mdc-benchmarks
+++ b/scripts/aeron/remote-archive-replay-mdc-benchmarks
@@ -400,7 +400,7 @@ do
           for (( i=0; i<runs; i++ ))
           do
             run=$((i + 1))
-            echo -e '\n### Benchmark run #'"${run}"' ...\n'
+            echo -e "\n\033[1;32m### [$(date +"%Y-%m-%d %H:%M:%S")] Benchmark run #${run} ...\033[0m\n"
 
             output_dir="${output_dir_prefix}/${test}_length=${messageLength}_rate=${messageRate}/run-${run}"
 

--- a/scripts/aeron/remote-cluster-benchmarks
+++ b/scripts/aeron/remote-cluster-benchmarks
@@ -481,7 +481,7 @@ do
           for (( i=0; i<runs; i++ ))
           do
             run=$((i + 1))
-            echo -e '\n### Benchmark run #'"${run}"' ...\n'
+            echo -e "\n\033[1;32m### [$(date +"%Y-%m-%d %H:%M:%S")] Benchmark run #${run} ...\033[0m\n"
 
             output_dir="${output_dir_prefix}/${client_md}-vs-${server_md}_${context}_fsync=${fsync}_mtu=${mtu}_length=${messageLength}_rate=${messageRate}/run-${run}"
 

--- a/scripts/aeron/remote-echo-mdc-benchmarks
+++ b/scripts/aeron/remote-echo-mdc-benchmarks
@@ -362,7 +362,7 @@ do
         for (( i=0; i<runs; i++ ))
         do
           run=$((i + 1))
-          echo -e '\n### Benchmark run #'"${run}"' ...\n'
+          echo -e "\n\033[1;32m### [$(date +"%Y-%m-%d %H:%M:%S")] Benchmark run #${run} ...\033[0m\n"
 
           output_dir="${output_dir_prefix}/${test}_length=${messageLength}_rate=${messageRate}/run-${run}"
 

--- a/scripts/aeron/remote-echo-single-host-benchmarks
+++ b/scripts/aeron/remote-echo-single-host-benchmarks
@@ -323,7 +323,7 @@ do
         for (( i=0; i<runs; i++ ))
         do
           run=$((i + 1))
-          echo -e '\n### Benchmark run #'"${run}"' ...\n'
+          echo -e "\n\033[1;32m### [$(date +"%Y-%m-%d %H:%M:%S")] Benchmark run #${run} ...\033[0m\n"
 
           output_dir="${output_dir_prefix}/${test}_length=${messageLength}_rate=${messageRate}/run-${run}"
 


### PR DESCRIPTION
Sometimes a benchmark gets stuck and it difficult to figure out based on the logging if this is the case because no timestamps are printed.

This PR adds timestamps to the start of a benchmark run of various benchmarks.

Logging will show something like
![image](https://github.com/user-attachments/assets/b3673421-16d1-4267-a1cb-880b64fd5c3a)
