### PR TITLE
Add fix for version conflict on protobuf.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,8 @@ allprojects {
                   "org.codehaus.plexus:plexus-utils:3.3.0",
                   "org.apache.commons:commons-lang3:3.8.1",
                   "org.apache.httpcomponents:httpcore:4.4.14",
-                  "commons-codec:commons-codec:1.15"
+                  "commons-codec:commons-codec:1.15",
+                  "com.google.protobuf:protobuf-java:3.25.5"
         }
     }
 }


### PR DESCRIPTION
Otherwise the following build error is the result

* What went wrong: Could not determine the dependencies of task ':benchmarks-all:shadowJar'.
> Could not resolve all dependencies for configuration ':benchmarks-all:runtimeClasspath'.
   > Conflict found for the following module:
       - com.google.protobuf:protobuf-java between versions 3.25.5 and 3.25.3