### PR TITLE
Added a timeout to pin_thread.

### DIFF
--- a/scripts/remote-benchmarks-runner
+++ b/scripts/remote-benchmarks-runner
@@ -189,6 +189,7 @@ function pin_thread()
   local core=${3}
   local tid_cmd="\$(ps Ho tid,comm -p ${pid} | awk '/${thread_name}/{print \$1}' | head -1)"
   echo "
+    set -e
     echo 'Pinning thread: ${thread_name}'
     count=0
     tid=${tid_cmd}


### PR DESCRIPTION
Also 2 cleanups were done to improve readability:

1) the string is placed over multiple lines
2) the variable containing the cmd to get the tid, is now renamed from tid to tid_cmd.