### PR TITLE
Add onBenchmarkStart/onBenchmarkComplete

### DIFF
--- a/benchmarks-api/src/main/java/io/aeron/benchmarks/LoadTestRig.java
+++ b/benchmarks-api/src/main/java/io/aeron/benchmarks/LoadTestRig.java
@@ -151,8 +151,9 @@ public final class LoadTestRig
                     configuration.warmupMessageRate(),
                     configuration.messageLength(),
                     configuration.batchSize());
+                messageTransceiver.onBenchmarkStart(true);
                 send(configuration.warmupIterations(), configuration.warmupMessageRate());
-
+                messageTransceiver.onBenchmarkComplete(true);
                 messageTransceiver.reset();
                 histogramSet.reset();
                 progressReporter.reset();
@@ -164,7 +165,10 @@ public final class LoadTestRig
                 configuration.messageRate(),
                 configuration.messageLength(),
                 configuration.batchSize());
+            messageTransceiver.onBenchmarkStart(false);
             final SendResult result = send(configuration.iterations(), configuration.messageRate());
+            messageTransceiver.onBenchmarkComplete(false);
+
             progressReporter.reset();
 
             out.printf("%nHistogram of RTT latencies in " + configuration.outputTimeUnit() + ".%n");

--- a/benchmarks-api/src/main/java/io/aeron/benchmarks/MessageTransceiver.java
+++ b/benchmarks-api/src/main/java/io/aeron/benchmarks/MessageTransceiver.java
@@ -173,6 +173,28 @@ public abstract class MessageTransceiver extends MessageTransceiverRhsPadding
         receivedMessages++;
     }
 
+    /**
+     * Called when the benchmark starts sending messages.
+     * <p>
+     * This method can be used to implement lifecycle logic.
+     *
+     * @param warmup if the benchmark is performing a warmup or the real benchmark.
+     */
+    public void onBenchmarkStart(final boolean warmup)
+    {
+    }
+
+    /**
+     * Called when the benchmark completes sending messages.
+     * <p>
+     * This method can be used to implement lifecycle logic.
+     *
+     * @param warmup if the benchmark is performing a warmup or the real benchmark.
+     */
+    public void onBenchmarkComplete(final boolean warmup)
+    {
+    }
+
     final void reset()
     {
         valueRecorder.reset();


### PR DESCRIPTION
Currently there are no lifecycle hooks on the MessageTransceiver so you can't listen to when a benchmark starts or completes. This PR changes that by adding 2 hooks

- onBenchmarkStart
- onBenchmarkComplete

For some more complex sequencer scenario's I need to have deterministic timer starts, so that different runs of the same benchmark trigger events at the same time offset. This way I can record HDR timeseries histograms (e.g. 10x a second) of different runs because it now guarantees full alignment of events.