### PR TITLE
Add receive amplification Configuration setting.

### DIFF
--- a/benchmarks-api/src/main/java/io/aeron/benchmarks/Configuration.java
+++ b/benchmarks-api/src/main/java/io/aeron/benchmarks/Configuration.java
@@ -200,11 +200,20 @@ public final class Configuration
     public static final String HISTOGRAM_LOGGING_INTERVAL_MS_PROP_NAME =
         "io.aeron.benchmarks.histogram.logging.interval.ms";
 
+    /**
+     * Name of the system property to configure the receive amplification.
+     */
+    public static final String RECEIVE_AMPLIFICATION_PROP_NAME = "io.aeron.benchmarks.receive.amplification";
 
     /**
      * Default receive deadline in seconds. Default value 3 seconds.
      */
     public static final int DEFAULT_RECEIVE_DEADLINE_SECONDS = 3;
+
+    /**
+     * Default receive amplification. Default value 1; so every request gets 1 response.
+     */
+    public static final int DEFAULT_RECEIVE_AMPLIFICATION = 1;
 
     /**
      * Max message rate allowed, i.e. 1 message per nanosecond.
@@ -231,6 +240,7 @@ public final class Configuration
     private final boolean reportProgress;
     private final TimeUnit outputTimeUnit;
     private final int receiveDeadlineSeconds;
+    private final int receiveAmplification;
 
     private Configuration(final Builder builder)
     {
@@ -252,6 +262,8 @@ public final class Configuration
         this.outputTimeUnit = builder.outputTimeUnit;
         this.receiveDeadlineSeconds = checkValueRange(builder.receiveDeadlineSeconds, 0, Integer.MAX_VALUE,
             RECEIVE_DEADLINE_SECONDS_PROP_NAME);
+        this.receiveAmplification = checkValueRange(
+            builder.receiveAmplification, 1, Integer.MAX_VALUE, RECEIVE_AMPLIFICATION_PROP_NAME);
         this.rate = rateAsString();
         this.outputFileNamePrefix = computeFileNamePrefix(builder.outputFileNamePrefix);
     }
@@ -416,6 +428,18 @@ public final class Configuration
         return outputFileNamePrefix;
     }
 
+    /**
+     * The receive message amplification. A value of n, indicates that for every send message,
+     * n messages are received.
+     *
+     * @return receive amplification, defaults to {@link #DEFAULT_RECEIVE_AMPLIFICATION}.
+     */
+    public int receiveAmplification()
+    {
+        return receiveAmplification;
+    }
+
+
     public String toString()
     {
         return "Configuration{" +
@@ -433,6 +457,7 @@ public final class Configuration
             "\n    receiveDeadlineSeconds=" + receiveDeadlineSeconds +
             "\n    outputDirectory=" + outputDirectory +
             "\n    outputFileNamePrefix=" + outputFileNamePrefix +
+            "\n    receiveAmplification=" + receiveAmplification +
             "\n}";
     }
 
@@ -485,6 +510,7 @@ public final class Configuration
         private boolean reportProgress = DEFAULT_REPORT_PROGRESS;
         private TimeUnit outputTimeUnit = TimeUnit.MICROSECONDS;
         private int receiveDeadlineSeconds = DEFAULT_RECEIVE_DEADLINE_SECONDS;
+        private int receiveAmplification = DEFAULT_RECEIVE_AMPLIFICATION;
 
         /**
          * Set the number of warmup iterations.
@@ -656,6 +682,21 @@ public final class Configuration
         }
 
         /**
+         * Set the receive amplification. With typical benchmarks, for every send message,
+         * a message is received. so there is a 1:1 ratio and hence the receive amplification is 1.
+         * But for certian benchmarks, e.g. sequencer and having multiple non-deterministic statemachines
+         * (so no response deduplication) multiple apps could send a response depending on the benchmark.
+         *
+         * @param receiveAmplification receive amplification.
+         * @return this for a fluent API.
+         */
+        public Builder receiveAmplification(final int receiveAmplification)
+        {
+            this.receiveAmplification = receiveAmplification;
+            return this;
+        }
+
+        /**
          * Create a new instance of the {@link Configuration} class from this builder.
          *
          * @return a {@link Configuration} instance
@@ -728,6 +769,11 @@ public final class Configuration
         if (isPropertyProvided(RECEIVE_DEADLINE_SECONDS_PROP_NAME))
         {
             builder.receiveDeadlineSeconds(intProperty(RECEIVE_DEADLINE_SECONDS_PROP_NAME));
+        }
+
+        if (isPropertyProvided(RECEIVE_AMPLIFICATION_PROP_NAME))
+        {
+            builder.receiveAmplification(intProperty(RECEIVE_AMPLIFICATION_PROP_NAME));
         }
 
         builder

--- a/benchmarks-api/src/main/java/io/aeron/benchmarks/LoadTestRig.java
+++ b/benchmarks-api/src/main/java/io/aeron/benchmarks/LoadTestRig.java
@@ -37,8 +37,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.agrona.PropertyAction.PRESERVE;
 import static org.agrona.PropertyAction.REPLACE;
 import static io.aeron.benchmarks.MessageTransceiver.CHECKSUM;
-import static io.aeron.benchmarks.PersistedHistogram.Status.FAIL;
-import static io.aeron.benchmarks.PersistedHistogram.Status.OK;
+
 import static io.aeron.benchmarks.PropertiesUtil.loadPropertiesFiles;
 import static io.aeron.benchmarks.PropertiesUtil.mergeWithSystemProperties;
 
@@ -56,6 +55,7 @@ public final class LoadTestRig
     private final NanoClock clock;
     private final PersistedHistogramSet histogramSet;
     private final ProgressReporter progressReporter;
+    private final int receiveAmplification;
 
     public LoadTestRig(final Configuration configuration)
     {
@@ -66,7 +66,7 @@ public final class LoadTestRig
         this.messageTransceiver = createTransceiver(configuration, this.clock, this.histogramSet, null);
         this.progressReporter = buildProgressReporter(configuration, this.out);
         this.receiveDeadlineNs = TimeUnit.SECONDS.toNanos(configuration.receiveDeadlineSeconds());
-
+        this.receiveAmplification = configuration.receiveAmplification();
     }
 
     public LoadTestRig(
@@ -82,6 +82,8 @@ public final class LoadTestRig
         this.messageTransceiver = createTransceiver(configuration, nanoClock, this.histogramSet, persistedHistogram);
         this.progressReporter = buildProgressReporter(configuration, out);
         this.receiveDeadlineNs = TimeUnit.SECONDS.toNanos(configuration.receiveDeadlineSeconds());
+        this.receiveAmplification = configuration.receiveAmplification();
+
     }
 
     public LoadTestRig(
@@ -99,6 +101,8 @@ public final class LoadTestRig
             .apply(nanoClock, persistedHistogram.valueRecorder());
         this.progressReporter = buildProgressReporter(configuration, out);
         this.receiveDeadlineNs = TimeUnit.SECONDS.toNanos(configuration.receiveDeadlineSeconds());
+        this.receiveAmplification = configuration.receiveAmplification();
+
     }
 
     LoadTestRig(
@@ -118,6 +122,7 @@ public final class LoadTestRig
             new PersistedHistogramSet(configuration);
         this.progressReporter = requireNonNull(progressReporter);
         this.receiveDeadlineNs = TimeUnit.SECONDS.toNanos(configuration.receiveDeadlineSeconds());
+        this.receiveAmplification = configuration.receiveAmplification();
     }
 
     /**
@@ -174,10 +179,15 @@ public final class LoadTestRig
             out.printf("%nHistogram of RTT latencies in " + configuration.outputTimeUnit() + ".%n");
             histogramSet.outputPercentileDistributions(out);
 
-            final long expectedTotalNumberOfMessages = configuration.iterations() * (long)configuration.messageRate();
-            warnIfTargetRateNotAchieved(result, expectedTotalNumberOfMessages);
+            final long expectedTotalNumberOfSendMessages =
+                configuration.iterations() * (long)configuration.messageRate();
+            final long expectedTotalNumberOfReceivedMessages =
+                expectedTotalNumberOfSendMessages * receiveAmplification;
+            warnIfTargetRateNotAchieved(
+                result, expectedTotalNumberOfSendMessages, expectedTotalNumberOfReceivedMessages);
 
-            final PersistedHistogram.Status status = result.status(expectedTotalNumberOfMessages);
+            final PersistedHistogram.Status status = result.status(
+                expectedTotalNumberOfSendMessages, expectedTotalNumberOfReceivedMessages);
             histogramSet.saveAll(status);
         }
         finally
@@ -233,7 +243,7 @@ public final class LoadTestRig
                         nextReportTimeNs += NANOS_PER_SECOND;
                     }
 
-                    if (receivedMessageCount < sentMessages)
+                    if (receivedMessageCount < receiveAmplification * sentMessages)
                     {
                         messageTransceiver.receive();
                         final long newReceivedMessageCount = messageTransceiver.receivedMessages();
@@ -276,7 +286,7 @@ public final class LoadTestRig
         idleStrategy.reset();
         long receivedMessageCount = messageTransceiver.receivedMessages();
         final long deadline = clock.nanoTime() + receiveDeadlineNs;
-        while (receivedMessageCount < sentMessages)
+        while (receivedMessageCount < receiveAmplification * sentMessages)
         {
             messageTransceiver.receive();
             final long newReceivedMessageCount = messageTransceiver.receivedMessages();
@@ -298,27 +308,30 @@ public final class LoadTestRig
         return new SendResult(sentMessages, receivedMessageCount);
     }
 
-    private void warnIfTargetRateNotAchieved(final SendResult result, final long expectedTotalNumberOfMessages)
+    private void warnIfTargetRateNotAchieved(
+        final SendResult result,
+        final long expectedTotalNumberOfMessagesSend,
+        final long expectedTotalNumberOfMessagesReceived)
     {
-        if (expectedTotalNumberOfMessages != result.sentMessages)
+        if (expectedTotalNumberOfMessagesSend != result.sentMessages)
         {
             out.printf(
                 "%n*** WARNING: Target message rate not achieved: expected to send %,d messages in " +
                 "total but managed to send only %,d messages (loss %.4f%%)!%n",
-                expectedTotalNumberOfMessages,
+                expectedTotalNumberOfMessagesSend,
                 result.sentMessages,
-                100.0 - (100.0 * result.sentMessages / expectedTotalNumberOfMessages));
+                100.0 - (100.0 * result.sentMessages / expectedTotalNumberOfMessagesSend));
         }
 
-        if (result.sentMessages != result.receivedMessages)
+        if (expectedTotalNumberOfMessagesReceived != result.receivedMessages)
         {
             out.printf(
                 "%n*** WARNING: Not all messages were received after %ds deadline: expected %,d vs received " +
                 "%,d (loss %.4f%%)!%n",
                 NANOSECONDS.toSeconds(receiveDeadlineNs),
-                result.sentMessages,
+                expectedTotalNumberOfMessagesReceived,
                 result.receivedMessages,
-                100.0 - (100.0 * result.receivedMessages / result.sentMessages));
+                100.0 - (100.0 * result.receivedMessages / expectedTotalNumberOfMessagesReceived));
         }
     }
 
@@ -408,9 +421,21 @@ public final class LoadTestRig
             this.receivedMessages = receivedMessages;
         }
 
-        PersistedHistogram.Status status(final long expectedNumberOfMessages)
+        PersistedHistogram.Status status(
+            final long expectedNumberOfSendMessages,
+            final long expectedNumberOfReceivedMessages)
         {
-            return expectedNumberOfMessages == sentMessages && expectedNumberOfMessages == receivedMessages ? OK : FAIL;
+            if (sentMessages != expectedNumberOfSendMessages)
+            {
+                return PersistedHistogram.Status.FAIL;
+            }
+
+            if (receivedMessages != expectedNumberOfReceivedMessages)
+            {
+                return PersistedHistogram.Status.FAIL;
+            }
+
+            return PersistedHistogram.Status.OK;
         }
     }
 }

--- a/benchmarks-api/src/test/java/io/aeron/benchmarks/ConfigurationTest.java
+++ b/benchmarks-api/src/test/java/io/aeron/benchmarks/ConfigurationTest.java
@@ -198,6 +198,36 @@ class ConfigurationTest
 
     @ParameterizedTest
     @ValueSource(ints = { Integer.MIN_VALUE, 0 })
+    void throwsIllegalArgumentExceptionIfReceiveAmplificationIsInvalid(
+        final int receiveAmplification)
+    {
+        final Builder builder = new Builder()
+            .messageRate(100)
+            .messageTransceiverClass(InMemoryMessageTransceiver.class)
+            .receiveAmplification(receiveAmplification);
+
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, builder::build);
+
+        assertEquals(
+            "'" + RECEIVE_AMPLIFICATION_PROP_NAME + "' cannot be less than 1, got: " +
+            receiveAmplification, ex.getMessage());
+    }
+
+    @Test
+    void receiveAmplificationCanBeSet()
+    {
+        final Configuration configuration = new Builder()
+            .messageRate(100)
+            .messageTransceiverClass(InMemoryMessageTransceiver.class)
+            .outputFileNamePrefix("test")
+            .receiveAmplification(5)
+            .build();
+
+        assertEquals(5, configuration.receiveAmplification());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, 0 })
     void throwsIllegalArgumentExceptionIfBatchSizeIsInvalid(final int size)
     {
         final Builder builder = new Builder()
@@ -414,6 +444,7 @@ class ConfigurationTest
         assertEquals(DEFAULT_BATCH_SIZE, configuration.batchSize());
         assertEquals(MIN_MESSAGE_LENGTH, configuration.messageLength());
         assertEquals(DEFAULT_RECEIVE_DEADLINE_SECONDS, configuration.receiveDeadlineSeconds());
+        assertEquals(DEFAULT_RECEIVE_AMPLIFICATION, configuration.receiveAmplification());
         assertSame(InMemoryMessageTransceiver.class, configuration.messageTransceiverClass());
         assertSame(BusySpinIdleStrategy.INSTANCE, configuration.idleStrategy());
         assertEquals(Paths.get("results").toAbsolutePath(), configuration.outputDirectory());
@@ -436,6 +467,7 @@ class ConfigurationTest
             .idleStrategy(YieldingIdleStrategy.INSTANCE)
             .outputDirectory(outputDirectory)
             .outputFileNamePrefix("explicit-opts")
+            .receiveAmplification(7)
             .build();
 
         assertEquals(3, configuration.warmupIterations());
@@ -448,6 +480,7 @@ class ConfigurationTest
         assertSame(YieldingIdleStrategy.INSTANCE, configuration.idleStrategy());
         assertEquals(outputDirectory.toAbsolutePath(), configuration.outputDirectory());
         assertTrue(configuration.outputFileNamePrefix().startsWith("explicit-opts"));
+        assertEquals(7, configuration.receiveAmplification());
     }
 
     @Test
@@ -480,6 +513,7 @@ class ConfigurationTest
             "\n    receiveDeadlineSeconds=3" +
             "\n    outputDirectory=" + Paths.get("results").toAbsolutePath() +
             "\n    outputFileNamePrefix=my-file_rate=777K_batch=2_length=64" +
+            "\n    receiveAmplification=1" +
             "\n}",
             configuration.toString());
     }
@@ -598,6 +632,7 @@ class ConfigurationTest
         assertEquals(Paths.get("results").toAbsolutePath(), configuration.outputDirectory());
         assertEquals(TimeUnit.DAYS, configuration.outputTimeUnit());
         assertEquals(DEFAULT_RECEIVE_DEADLINE_SECONDS, configuration.receiveDeadlineSeconds());
+        assertEquals(DEFAULT_RECEIVE_AMPLIFICATION, configuration.receiveAmplification());
     }
 
     @Test
@@ -617,6 +652,7 @@ class ConfigurationTest
         setProperty(TRACK_HISTORY_PROP_NAME, "true");
         setProperty(REPORT_PROGRESS_PROP_NAME, "false");
         setProperty(RECEIVE_DEADLINE_SECONDS_PROP_NAME, "60");
+        setProperty(RECEIVE_AMPLIFICATION_PROP_NAME, "9");
 
         final Configuration configuration = fromSystemProperties();
 
@@ -633,6 +669,7 @@ class ConfigurationTest
         assertEquals(outputDirectory.toAbsolutePath(), configuration.outputDirectory());
         assertTrue(configuration.outputFileNamePrefix().startsWith("my-out-file"));
         assertEquals(60, configuration.receiveDeadlineSeconds());
+        assertEquals(9, configuration.receiveAmplification());
     }
 
     @Test
@@ -692,7 +729,8 @@ class ConfigurationTest
             IDLE_STRATEGY_PROP_NAME,
             OUTPUT_DIRECTORY_PROP_NAME,
             OUTPUT_FILE_NAME_PROP_NAME,
-                RECEIVE_DEADLINE_SECONDS_PROP_NAME)
+            RECEIVE_DEADLINE_SECONDS_PROP_NAME,
+                RECEIVE_AMPLIFICATION_PROP_NAME)
             .forEach(System::clearProperty);
     }
 

--- a/benchmarks-api/src/test/java/io/aeron/benchmarks/LoadTestRigTest.java
+++ b/benchmarks-api/src/test/java/io/aeron/benchmarks/LoadTestRigTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 
 import java.io.File;
@@ -408,5 +410,47 @@ class LoadTestRigTest
         final IllegalStateException exception = assertThrows(IllegalStateException.class, loadTestRig::run);
         assertSame(initException, exception);
         verify(messageTransceiver).destroy();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3})
+    void receiveShouldKeepReceivingMessagesUpToTheAmplifiedSentMessagesLimit(
+        final int receiveAmplification)
+    {
+        final int messageRate = 3;
+        configuration = new Configuration.Builder()
+            .warmupIterations(0)
+            .iterations(1)
+            .messageRate(messageRate)
+            .batchSize(200)
+            .receiveAmplification(receiveAmplification)
+            .outputTimeUnit(MINUTES)
+            .messageTransceiverClass(configuration.messageTransceiverClass())
+            .idleStrategy(idleStrategy)
+            .outputDirectory(configuration.outputDirectory())
+            .outputFileNamePrefix("test")
+            .build();
+
+        final LoadTestRig loadTestRig = new LoadTestRig(
+            configuration,
+            messageTransceiver,
+            out,
+            clock,
+            persistedHistogram,
+            progressReporter);
+
+        final LoadTestRig.SendResult result = loadTestRig.send(1, messageRate);
+
+        final int expectedReceivedMessages = messageRate * receiveAmplification;
+
+        assertEquals(messageRate, result.sentMessages);
+        assertEquals(expectedReceivedMessages, result.receivedMessages);
+
+        verify(messageTransceiver).send(anyInt(), anyInt(), anyLong(), anyLong());
+        verify(messageTransceiver, times(expectedReceivedMessages)).receive();
+        verify(messageTransceiver, times(expectedReceivedMessages + 1)).receivedMessages();
+        verify(messageTransceiver, times(expectedReceivedMessages)).onMessageReceived(anyLong(), anyLong());
+        verify(idleStrategy, times(expectedReceivedMessages + 1)).reset();
+        verifyNoMoreInteractions(messageTransceiver, idleStrategy);
     }
 }


### PR DESCRIPTION
In most benchmarks, every request will have a single response. So the receive amplification is 1.

But when testing sequencer with multiple active non-deterministic applications (so the sequencer will not deduplicate responses), a single request can get multiple responses (from each active application you get 1 response).

With this new configuration settings, the LoadTestRig can properly handle such situations.